### PR TITLE
O3-1438: Implement the Schema Editor Component

### DIFF
--- a/__mocks__/react-i18next.js
+++ b/__mocks__/react-i18next.js
@@ -1,14 +1,16 @@
 /** At present, this entire mock is boilerplate. */
 
-const React = require('react');
-const reactI18next = require('react-i18next');
+const React = require("react");
+const reactI18next = require("react-i18next");
 
-const hasChildren = node => node && (node.children || (node.props && node.props.children));
+const hasChildren = (node) =>
+  node && (node.children || (node.props && node.props.children));
 
-const getChildren = node => (node && node.children ? node.children : node.props && node.props.children);
+const getChildren = (node) =>
+  node && node.children ? node.children : node.props && node.props.children;
 
-const renderNodes = reactNodes => {
-  if (typeof reactNodes === 'string') {
+const renderNodes = (reactNodes) => {
+  if (typeof reactNodes === "string") {
     return reactNodes;
   }
 
@@ -16,29 +18,32 @@ const renderNodes = reactNodes => {
     const child = reactNodes[key];
     const isElement = React.isValidElement(child);
 
-    if (typeof child === 'string') {
+    if (typeof child === "string") {
       return child;
     }
     if (hasChildren(child)) {
       const inner = renderNodes(getChildren(child));
       return React.cloneElement(child, { ...child.props, key: i }, inner);
     }
-    if (typeof child === 'object' && !isElement) {
-      return Object.keys(child).reduce((str, childKey) => `${str}${child[childKey]}`, '');
+    if (typeof child === "object" && !isElement) {
+      return Object.keys(child).reduce(
+        (str, childKey) => `${str}${child[childKey]}`,
+        ""
+      );
     }
 
     return child;
   });
 };
 
-const useMock = [k => k, {}];
-useMock.t = (k, o) => (o && o.defaultValue) || (typeof o === 'string' ? o : k);
+const useMock = [(k) => k, {}];
+useMock.t = (k, o) => (o && o.defaultValue) || (typeof o === "string" ? o : k);
 useMock.i18n = {};
 
 module.exports = {
   // this mock makes sure any components using the translate HoC receive the t function as a prop
   Trans: ({ children }) => renderNodes(children),
-  Translation: ({ children }) => children(k => k, { i18n: {} }),
+  Translation: ({ children }) => children((k) => k, { i18n: {} }),
   useTranslation: () => useMock,
 
   // mock if needed

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   "dependencies": {
     "@carbon/icons-react": "^10.18.0",
     "carbon-components-react": "^7.25.0",
-    "lodash-es": "^4.17.15"
+    "lodash-es": "^4.17.15",
+    "react-ace": "^10.1.0"
   },
   "peerDependencies": {
     "@openmrs/esm-framework": "^3.14.0-pre",

--- a/src/api/fetchFormDetail.ts
+++ b/src/api/fetchFormDetail.ts
@@ -1,0 +1,36 @@
+import useSWR from "swr";
+import { openmrsFetch } from "@openmrs/esm-framework";
+import { Form, Schema } from "../api/types";
+
+export const useFormMetadata = (uuid: string) => {
+  const url = `/ws/rest/v1/form/${uuid}?v=full`;
+  const { data, error } = useSWR<{ data: Form }, Error>(url, openmrsFetch);
+  return {
+    formMetaData: data?.data,
+    isFormMetaDataLoading: !error && !data,
+    formMetaDataError: error,
+  };
+};
+
+export const useFormSchema = (form: Form) => {
+  const GetDefaultSchema = () => {
+    const schema: Schema = {
+      name: "",
+      pages: [],
+      processor: "EncounterFormProcessor",
+      uuid: "xxx",
+      referencedForms: [],
+    };
+    return schema;
+  };
+  const url =
+    form?.resources.length == 0 || !form?.resources[0]
+      ? null
+      : `/ws/rest/v1/clobdata/${form?.resources[0].valueReference}`;
+  const { data, error } = useSWR<{ data: string }, Error>(url, openmrsFetch);
+  return {
+    formSchemaData: data == null ? GetDefaultSchema() : data?.data,
+    isSchemaLoading: !error && !data,
+    formSchemaError: error,
+  };
+};

--- a/src/api/fetchFormDetail.ts
+++ b/src/api/fetchFormDetail.ts
@@ -1,21 +1,40 @@
 import useSWRImmutable from "swr/immutable";
-import { openmrsFetch } from "@openmrs/esm-framework";
+import { openmrsFetch, showToast } from "@openmrs/esm-framework";
 import { Form, Schema } from "../api/types";
 
 export const useFormMetadata = (uuid: string) => {
-  const url = `/ws/rest/v1/form/${uuid}?v=full`;
+  const url = uuid == "new" ? null : `/ws/rest/v1/form/${uuid}?v=full`;
   const { data, error } = useSWRImmutable<{ data: Form }, Error>(
     url,
     openmrsFetch
   );
-  return {
-    formMetaData: data?.data,
-    isFormMetaDataLoading: !error && !data,
-    formMetaDataError: error,
-  };
+  if (error) {
+    showToast({
+      title: "Error",
+      kind: "error",
+      critical: true,
+      description: `${error.message}`,
+    });
+  }
+  if (uuid == "new") {
+    return {
+      formMetaData: null,
+    };
+  } else {
+    return {
+      formMetaData: data?.data,
+    };
+  }
 };
 
-export const useFormSchema = (form: Form) => {
+export const useFormSchema = (form?: Form) => {
+  const schema: Schema = {
+    name: "",
+    pages: [],
+    processor: "EncounterFormProcessor",
+    uuid: "xxx",
+    referencedForms: [],
+  };
   const url =
     form?.resources.length == 0 || !form?.resources[0]
       ? null
@@ -24,9 +43,21 @@ export const useFormSchema = (form: Form) => {
     url,
     openmrsFetch
   );
-  return {
-    formSchemaData: data?.data,
-    isSchemaLoading: !error && !data,
-    formSchemaError: error,
-  };
+  if (error) {
+    showToast({
+      title: "Error",
+      kind: "error",
+      critical: true,
+      description: `${error.message}`,
+    });
+  }
+  if (url == null) {
+    return {
+      formSchemaData: schema,
+    };
+  } else {
+    return {
+      formSchemaData: data?.data,
+    };
+  }
 };

--- a/src/api/fetchFormDetail.ts
+++ b/src/api/fetchFormDetail.ts
@@ -1,10 +1,13 @@
-import useSWR from "swr";
+import useSWRImmutable from "swr/immutable";
 import { openmrsFetch } from "@openmrs/esm-framework";
 import { Form, Schema } from "../api/types";
 
 export const useFormMetadata = (uuid: string) => {
   const url = `/ws/rest/v1/form/${uuid}?v=full`;
-  const { data, error } = useSWR<{ data: Form }, Error>(url, openmrsFetch);
+  const { data, error } = useSWRImmutable<{ data: Form }, Error>(
+    url,
+    openmrsFetch
+  );
   return {
     formMetaData: data?.data,
     isFormMetaDataLoading: !error && !data,
@@ -13,23 +16,16 @@ export const useFormMetadata = (uuid: string) => {
 };
 
 export const useFormSchema = (form: Form) => {
-  const GetDefaultSchema = () => {
-    const schema: Schema = {
-      name: "",
-      pages: [],
-      processor: "EncounterFormProcessor",
-      uuid: "xxx",
-      referencedForms: [],
-    };
-    return schema;
-  };
   const url =
     form?.resources.length == 0 || !form?.resources[0]
       ? null
       : `/ws/rest/v1/clobdata/${form?.resources[0].valueReference}`;
-  const { data, error } = useSWR<{ data: string }, Error>(url, openmrsFetch);
+  const { data, error } = useSWRImmutable<{ data: Schema }, Error>(
+    url,
+    openmrsFetch
+  );
   return {
-    formSchemaData: data == null ? GetDefaultSchema() : data?.data,
+    formSchemaData: data?.data,
     isSchemaLoading: !error && !data,
     formSchemaError: error,
   };

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -19,3 +19,11 @@ export interface Resource {
   dataType: string;
   valueReference: string;
 }
+
+export interface Schema {
+  name: string;
+  pages: any;
+  processor: string;
+  uuid: string;
+  referencedForms: any;
+}

--- a/src/components/dashboard/dashboard.component.tsx
+++ b/src/components/dashboard/dashboard.component.tsx
@@ -16,6 +16,7 @@ import {
   Button,
   Tag,
 } from "carbon-components-react";
+import { navigate } from "@openmrs/esm-framework";
 import { Download, Edit, DocumentImport } from "@carbon/icons-react/next";
 import { useTranslation } from "react-i18next";
 import { usePOCForms } from "../../api/usePOCForms";
@@ -53,6 +54,7 @@ const Dashboard: React.FC = () => {
           <Button
             className={styles.importButton}
             renderIcon={DocumentImport}
+            onClick={() => navigate({ to: `form-builder/edit/${form.uuid}` })}
             kind={"ghost"}
             iconDescription={t("import", "Import")}
             hasIconOnly
@@ -62,6 +64,11 @@ const Dashboard: React.FC = () => {
             <Button
               className={styles.editButton}
               renderIcon={Edit}
+              onClick={() =>
+                navigate({
+                  to: `${window.spaBase}/form-builder/edit/${form.uuid}`,
+                })
+              }
               kind={"ghost"}
               iconDescription={t("editForm", "Edit Form")}
               hasIconOnly
@@ -128,7 +135,15 @@ const Dashboard: React.FC = () => {
                   <TableToolbarMenu>
                     <TableToolbarAction>POC</TableToolbarAction>
                   </TableToolbarMenu>
-                  <Button>Create New</Button>
+                  <Button
+                    onClick={() =>
+                      navigate({
+                        to: `${window.spaBase}/form-builder/edit/new`,
+                      })
+                    }
+                  >
+                    {t("createNew", "Create New")}
+                  </Button>
                 </TableToolbarContent>
               </TableToolbar>
             </div>

--- a/src/components/form-editor/form-editor.scss
+++ b/src/components/form-editor/form-editor.scss
@@ -1,0 +1,3 @@
+.wrap {
+  margin-top: 1rem;
+}

--- a/src/components/form-editor/form-editor.tsx
+++ b/src/components/form-editor/form-editor.tsx
@@ -1,67 +1,19 @@
 import React from "react";
 import { Column, Row, Tabs, Tab } from "carbon-components-react";
 import { useTranslation } from "react-i18next";
-import { showToast } from "@openmrs/esm-framework";
 import SchemaEditorComponent from "./schema-editor/schema-editor.component";
 import styles from "./form-editor.scss";
 import { useParams } from "react-router-dom";
 import { useFormSchema, useFormMetadata } from "../../api/fetchFormDetail";
-import { Form, Schema } from "../../api/types";
 
 const FormEditor: React.FC = () => {
-  type State = {
+  type Route = {
     uuid: string;
   };
   const { t } = useTranslation();
-  const { uuid } = useParams<State>();
-
-  const GetFormMetaData = (formUUID: string) => {
-    const { formMetaData, formMetaDataError } = useFormMetadata(formUUID);
-    if (formMetaDataError) {
-      showToast({
-        title: t("error", "Error"),
-        kind: "error",
-        critical: true,
-        description: `${formMetaDataError?.message}`,
-      });
-    }
-    return formMetaData;
-  };
-
-  const GetFormSchema = (form: Form) => {
-    const { formSchemaData, isSchemaLoading, formSchemaError } =
-      useFormSchema(form);
-    if (form?.resources.length !== 0) {
-      if (formSchemaError) {
-        showToast({
-          title: t("error", "Error"),
-          kind: "error",
-          critical: true,
-          description: `${formSchemaError?.message}`,
-        });
-      }
-      if (isSchemaLoading) {
-        return "Loading...";
-      }
-      return formSchemaData;
-    } else {
-      return GetRawSchema();
-    }
-  };
-
-  const GetRawSchema = () => {
-    const schema: Schema = {
-      name: "",
-      pages: [],
-      processor: "EncounterFormProcessor",
-      uuid: "xxx",
-      referencedForms: [],
-    };
-    return schema;
-  };
-
-  const formData = uuid == "new" ? null : GetFormMetaData(uuid);
-  const formSchema = uuid == "new" ? GetRawSchema() : GetFormSchema(formData);
+  const { uuid } = useParams<Route>();
+  const { formMetaData } = useFormMetadata(uuid);
+  const { formSchemaData } = useFormSchema(formMetaData);
 
   return (
     <div className={styles.wrap}>
@@ -69,7 +21,7 @@ const FormEditor: React.FC = () => {
         <Column lg={6} md={6} className={styles.grid}>
           <Tabs>
             <Tab label={t("schemaEditor", "Schema Editor")}>
-              <SchemaEditorComponent schema={formSchema} />
+              <SchemaEditorComponent schema={formSchemaData} />
             </Tab>
             <Tab label={t("interactiveBuilder", "Interactive Builder")}>
               {t("interactiveBuilder", "Interactive Builder")}

--- a/src/components/form-editor/form-editor.tsx
+++ b/src/components/form-editor/form-editor.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { Column, Row, Tabs, Tab } from "carbon-components-react";
+import { useTranslation } from "react-i18next";
+import { showToast } from "@openmrs/esm-framework";
+import SchemaEditorComponent from "./schema-editor/schema-editor.component";
+import styles from "./form-editor.scss";
+import { useParams } from "react-router-dom";
+import { useFormSchema, useFormMetadata } from "../../api/fetchFormDetail";
+import { Form, Schema } from "../../api/types";
+
+const GetFormMetaData = (formUUID: string) => {
+  const { formMetaData, formMetaDataError } = useFormMetadata(formUUID);
+  if (formMetaDataError) {
+    console.error(formMetaData);
+  }
+  return formMetaData;
+};
+
+const GetFormSchema = (form: Form) => {
+  const { formSchemaData, formSchemaError } = useFormSchema(form);
+  if (formSchemaError) {
+    console.error(formSchemaError);
+  }
+  return formSchemaData;
+};
+
+const GetRawSchema = () => {
+  const schema: Schema = {
+    name: "",
+    pages: [],
+    processor: "EncounterFormProcessor",
+    uuid: "xxx",
+    referencedForms: [],
+  };
+  return schema;
+};
+
+const FormEditor: React.FC = () => {
+  const { t } = useTranslation();
+  const { uuid } = useParams<State>();
+  type State = {
+    uuid: string;
+  };
+
+  const formData = uuid == "new" ? null : GetFormMetaData(uuid);
+  const formSchema = uuid == "new" ? GetRawSchema() : GetFormSchema(formData);
+
+  return (
+    <div className={styles.wrap}>
+      <Row>
+        <Column lg={6} md={6} className={styles.grid}>
+          <Tabs>
+            <Tab label={t("schemaEditor", "Schema Editor")}>
+              <SchemaEditorComponent schema={formSchema} />
+            </Tab>
+            <Tab label={t("interactiveBuilder", "Interactive Builder")}>
+              {t("interactiveBuilder", "Interactive Builder")}
+            </Tab>
+          </Tabs>
+        </Column>
+        <Column lg={6} md={6}>
+          <Tabs>
+            <Tab label={t("formViewer", "Form Viewer")}>
+              {t("formViewer", "Form Viewer")}
+            </Tab>
+          </Tabs>
+        </Column>
+      </Row>
+    </div>
+  );
+};
+
+export default FormEditor;

--- a/src/components/form-editor/form-editor.tsx
+++ b/src/components/form-editor/form-editor.tsx
@@ -8,38 +8,56 @@ import { useParams } from "react-router-dom";
 import { useFormSchema, useFormMetadata } from "../../api/fetchFormDetail";
 import { Form, Schema } from "../../api/types";
 
-const GetFormMetaData = (formUUID: string) => {
-  const { formMetaData, formMetaDataError } = useFormMetadata(formUUID);
-  if (formMetaDataError) {
-    console.error(formMetaData);
-  }
-  return formMetaData;
-};
-
-const GetFormSchema = (form: Form) => {
-  const { formSchemaData, formSchemaError } = useFormSchema(form);
-  if (formSchemaError) {
-    console.error(formSchemaError);
-  }
-  return formSchemaData;
-};
-
-const GetRawSchema = () => {
-  const schema: Schema = {
-    name: "",
-    pages: [],
-    processor: "EncounterFormProcessor",
-    uuid: "xxx",
-    referencedForms: [],
-  };
-  return schema;
-};
-
 const FormEditor: React.FC = () => {
-  const { t } = useTranslation();
-  const { uuid } = useParams<State>();
   type State = {
     uuid: string;
+  };
+  const { t } = useTranslation();
+  const { uuid } = useParams<State>();
+
+  const GetFormMetaData = (formUUID: string) => {
+    const { formMetaData, formMetaDataError } = useFormMetadata(formUUID);
+    if (formMetaDataError) {
+      showToast({
+        title: t("error", "Error"),
+        kind: "error",
+        critical: true,
+        description: `${formMetaDataError?.message}`,
+      });
+    }
+    return formMetaData;
+  };
+
+  const GetFormSchema = (form: Form) => {
+    const { formSchemaData, isSchemaLoading, formSchemaError } =
+      useFormSchema(form);
+    if (form?.resources.length !== 0) {
+      if (formSchemaError) {
+        showToast({
+          title: t("error", "Error"),
+          kind: "error",
+          critical: true,
+          description: `${formSchemaError?.message}`,
+        });
+      }
+      if (isSchemaLoading) {
+        return "Loading...";
+      }
+      return formSchemaData;
+    } else {
+      return GetRawSchema();
+    }
+  };
+
+  const GetRawSchema = () => {
+    const schema: Schema = {
+      name: "",
+      pages: [],
+      processor: "EncounterFormProcessor",
+      uuid: "xxx",
+      referencedForms: [],
+    };
+    return schema;
   };
 
   const formData = uuid == "new" ? null : GetFormMetaData(uuid);

--- a/src/components/form-editor/schema-editor/schema-editor.component.tsx
+++ b/src/components/form-editor/schema-editor/schema-editor.component.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { showToast } from "@openmrs/esm-framework";
+import { Button, Loading } from "carbon-components-react";
+import styles from "./schema-editor.scss";
+import AceEditor from "react-ace";
+import { useTranslation } from "react-i18next";
+
+interface SchemaParameters {
+  schema: any;
+}
+
+const SchemaEditorComponent: React.FC<SchemaParameters> = (schema) => {
+  const { t } = useTranslation();
+  let formSchema: string;
+
+  const updateFormJson = (value) => {
+    formSchema = value;
+  };
+
+  const render = () => {
+    try {
+      typeof formSchema == "string" ? JSON.parse(formSchema) : formSchema;
+    } catch (error) {
+      showToast({
+        title: t("error", "Error"),
+        kind: "error",
+        critical: true,
+        description: `${error}`,
+      });
+    }
+  };
+
+  return (
+    <div>
+      <h4>{t("schemaEditor", "Schema Editor")}</h4>
+      <AceEditor
+        placeholder="Schema"
+        mode="json"
+        theme="github"
+        name="schemaEditor"
+        onChange={updateFormJson}
+        fontSize={14}
+        showPrintMargin={true}
+        showGutter={true}
+        highlightActiveLine={true}
+        value={JSON.stringify(schema?.schema, null, "\t")}
+        setOptions={{
+          enableBasicAutocompletion: false,
+          enableLiveAutocompletion: false,
+          displayIndentGuides: false,
+          enableSnippets: false,
+          showLineNumbers: true,
+          tabSize: 2,
+        }}
+      />
+      <Button className={styles.renderButton} onClick={render}>
+        {t("render", "Render")}
+      </Button>
+    </div>
+  );
+};
+export default SchemaEditorComponent;

--- a/src/components/form-editor/schema-editor/schema-editor.component.tsx
+++ b/src/components/form-editor/schema-editor/schema-editor.component.tsx
@@ -3,9 +3,10 @@ import { Button } from "carbon-components-react";
 import styles from "./schema-editor.scss";
 import AceEditor from "react-ace";
 import { useTranslation } from "react-i18next";
+import { Schema } from "../../../api/types";
 
 interface SchemaEditorProps {
-  schema: any;
+  schema: Schema;
 }
 
 const SchemaEditorComponent: React.FC<SchemaEditorProps> = ({ schema }) => {

--- a/src/components/form-editor/schema-editor/schema-editor.component.tsx
+++ b/src/components/form-editor/schema-editor/schema-editor.component.tsx
@@ -14,13 +14,6 @@ const SchemaEditorComponent: React.FC<SchemaEditorProps> = ({ schema }) => {
   const [formSchema, setFormSchema] = useState<string>("");
   const [errorMessage, setErrorMessage] = useState("");
 
-  const updateFormJson = useCallback(
-    (value) => {
-      setFormSchema(value);
-    },
-    [setFormSchema]
-  );
-
   const render = useCallback(() => {
     setErrorMessage("");
     try {
@@ -44,7 +37,7 @@ const SchemaEditorComponent: React.FC<SchemaEditorProps> = ({ schema }) => {
         mode="json"
         theme="github"
         name="schemaEditor"
-        onChange={updateFormJson}
+        onChange={(value) => setFormSchema(value)}
         fontSize={14}
         showPrintMargin={true}
         showGutter={true}

--- a/src/components/form-editor/schema-editor/schema-editor.scss
+++ b/src/components/form-editor/schema-editor/schema-editor.scss
@@ -1,0 +1,3 @@
+.renderButton {
+  margin-top: 1rem;
+}

--- a/src/components/form-editor/schema-editor/schema-editor.scss
+++ b/src/components/form-editor/schema-editor/schema-editor.scss
@@ -1,3 +1,8 @@
 .renderButton {
   margin-top: 1rem;
 }
+
+.inputErrorMessage {
+  padding: 10px 0 15px 0;
+  color: red;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,8 +14,7 @@ const backendDependencies = {
 
 function setupOpenMRS() {
   const moduleName = "@openmrs/esm-form-builder";
-  const route = `form-builder`;
-  const spaBasePath = `${window.spaBase}/${route}`;
+  const spaBasePath = `${window.spaBase}/form-builder`;
 
   const options = {
     featureName: "form-builder",
@@ -26,7 +25,7 @@ function setupOpenMRS() {
     pages: [
       {
         load: getAsyncLifecycle(() => import("./root.component"), options),
-        route,
+        route: "form-builder",
       },
     ],
     extensions: [],

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,8 @@ const backendDependencies = {
 
 function setupOpenMRS() {
   const moduleName = "@openmrs/esm-form-builder";
+  const route = `form-builder`;
+  const spaBasePath = `${window.spaBase}/${route}`;
 
   const options = {
     featureName: "form-builder",
@@ -23,8 +25,8 @@ function setupOpenMRS() {
   return {
     pages: [
       {
-        load: getAsyncLifecycle(() => import("./form-builder"), options),
-        route: "form-builder",
+        load: getAsyncLifecycle(() => import("./root.component"), options),
+        route,
       },
     ],
     extensions: [],

--- a/src/root.component.tsx
+++ b/src/root.component.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { BrowserRouter, Route } from "react-router-dom";
+import FormBuilder from "./form-builder";
+import FormEditor from "./components/form-editor/form-editor";
+
+const RootComponent: React.FC = () => {
+  return (
+    <BrowserRouter basename={`${window.spaBase}/form-builder`}>
+      <Route exact path="/" component={FormBuilder} />
+      <Route exact path="/edit/:uuid" component={FormEditor} />
+    </BrowserRouter>
+  );
+};
+
+export default RootComponent;

--- a/translations/en.json
+++ b/translations/en.json
@@ -9,5 +9,10 @@
   "editForm": "Edit Form",
   "download": "Download",
   "import": "Import",
-  "formBuilder": "Form Builder"
+  "formBuilder": "Form Builder",
+  "schemaEditor": "Schema Editor",
+  "interactiveBuilder": "Interactive Builder",
+  "formViewer": "Form Viewer",
+  "createNew": "Create New",
+  "render": "Render"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2774,6 +2774,11 @@ accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.8:
     mime-types "~2.1.34"
     negotiator "0.6.3"
 
+ace-builds@^1.4.14:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/ace-builds/-/ace-builds-1.8.0.tgz#feffab6851f9ffcf7bccf9901300b76f923617ad"
+  integrity sha512-VearXS2mQBeF5sSaWJjLrer41PCROoK/69ai2Q8Q4GBQL0hD/Ny1CIv1EvH4miHM2B4d9zeKFUkozOM4wJszZg==
+
 acorn-globals@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-6.0.0.tgz#46cdd39f0f8ff08a876619b55f5ac8a6dc770b45"
@@ -4431,6 +4436,11 @@ dexie@^3.0.3:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/dexie/-/dexie-3.2.2.tgz#fa6f2a3c0d6ed0766f8d97a03720056f88fe0e01"
   integrity sha512-q5dC3HPmir2DERlX+toCBbHQXW5MsyrFqPFcovkH9N2S/UW/H3H5AWAB6iEOExeraAu+j+zRDG+zg/D7YhH0qg==
+
+diff-match-patch@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/diff-match-patch/-/diff-match-patch-1.0.5.tgz#abb584d5f10cd1196dfc55aa03701592ae3f7b37"
+  integrity sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==
 
 diff-sequences@^26.6.2:
   version "26.6.2"
@@ -6978,6 +6988,11 @@ lodash.findlast@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.findlast/-/lodash.findlast-4.6.0.tgz#ea8bb78cf2e7e7804fc8aeb7d1953e07fe31fbc8"
   integrity sha512-+OGwb1FVKjhc2aIEQ9vKqNDW1a0/HaCLr0iCIK10jfVif3dBE0nhQD0jOZNZLh7zOlmFUTrk+vt85eXoH4vKuA==
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
+
 lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
@@ -8187,6 +8202,17 @@ raw-body@2.5.1:
     http-errors "2.0.0"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
+
+react-ace@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/react-ace/-/react-ace-10.1.0.tgz#d348eac2b16475231779070b6cd16768deed565f"
+  integrity sha512-VkvUjZNhdYTuKOKQpMIZi7uzZZVgzCjM7cLYu6F64V0mejY8a2XTyPUIMszC6A4trbeMIHbK5fYFcT/wkP/8VA==
+  dependencies:
+    ace-builds "^1.4.14"
+    diff-match-patch "^1.0.5"
+    lodash.get "^4.4.2"
+    lodash.isequal "^4.5.0"
+    prop-types "^15.7.2"
 
 react-dom@^16.13.1, react-dom@^16.14.0:
   version "16.14.0"


### PR DESCRIPTION
### Purpose
Implement the schema editor component.

### Approach
- Fetch form schema according to the selected form in the form editor.
- If the form does have a schema form display a template schema on the editor.
- Throws an error is the JSON schema has a syntax error.

#### On create new form `form-builder/edit/new`
<img width="1434" alt="Screenshot 2022-07-28 at 9 43 35 PM" src="https://user-images.githubusercontent.com/27630091/181587997-dba5e7ad-1ffe-4998-86cf-03ecc2050c0a.png">

#### On a form with schema `form-builder/edit/{form-uuid}`
<img width="1441" alt="Screenshot 2022-07-28 at 9 44 08 PM" src="https://user-images.githubusercontent.com/27630091/181587993-ad2bbd94-bb02-4938-8502-88f3177acee6.png">

#### JSON Error
<img width="1438" alt="Screenshot 2022-07-28 at 9 45 34 PM" src="https://user-images.githubusercontent.com/27630091/181587980-b0c5ae00-fc56-48f3-9634-c650a8c9e316.png">

#### On a form with no schema `form-builder/edit/{form-uuid}`
<img width="1434" alt="Screenshot 2022-07-28 at 9 45 59 PM" src="https://user-images.githubusercontent.com/27630091/182068939-98695dda-4232-481d-9755-29d95037a64c.png">