### PR TITLE
(chore) Fix coverage script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "typescript": "tsc",
     "test": "jest --config jest.config.json",
     "verify": "concurrently 'yarn:lint' 'yarn:test' 'yarn:typescript'",
-    "coverage": "yarn test -- --coverage",
+    "coverage": "yarn test --coverage",
     "prepare": "husky install"
   },
   "husky": {


### PR DESCRIPTION
Removes an unnecessary `--` from the `--coverage` flag passed to `yarn test` in the coverage script.