### PR TITLE
(feat) Move error rendering logic to components

### DIFF
--- a/src/components/form-editor/form-editor.tsx
+++ b/src/components/form-editor/form-editor.tsx
@@ -23,20 +23,21 @@ import { publish, unpublish } from "../../forms.resource";
 import ElementEditor from "./element-editor/element-editor";
 import FormRenderer from "./form-renderer/form-renderer";
 
+type Route = {
+  uuid: string;
+};
+
 const FormEditor: React.FC = () => {
-  type Route = {
-    uuid: string;
-  };
   const { t } = useTranslation();
   const { uuid } = useParams<Route>();
-  const { formMetaData } = useFormMetadata(uuid);
-  const { formSchemaData, isLoading } = useFormClobdata(formMetaData);
+  const { metadata } = useFormMetadata(uuid);
+  const { formSchemaData, isLoading } = useFormClobdata(metadata);
   const [schema, setSchema] = useState<any>();
 
   const handlePublishState = async (option) => {
     if (option == "publish") {
       try {
-        await publish(formMetaData?.uuid);
+        await publish(metadata?.uuid);
         showToast({
           title: t("success", "Success!"),
           kind: "success",
@@ -53,7 +54,7 @@ const FormEditor: React.FC = () => {
       }
     } else if (option == "unpublish") {
       try {
-        await unpublish(formMetaData?.uuid);
+        await unpublish(metadata?.uuid);
         showToast({
           title: t("success", "Success!"),
           kind: "success",
@@ -82,8 +83,8 @@ const FormEditor: React.FC = () => {
     <SchemaContext.Provider value={{ schema, setSchema }}>
       <div className={styles.wrapContainer}>
         <div className={styles.actionsContainer}>
-          <SaveForm form={formMetaData} />
-          {formMetaData?.published == true ? (
+          <SaveForm form={metadata} />
+          {metadata?.published == true ? (
             <Button
               className={styles.optionButtons}
               onClick={() => handlePublishState("unpublish")}
@@ -91,7 +92,7 @@ const FormEditor: React.FC = () => {
             >
               {t("unpublishForm", "Unpublish form")}
             </Button>
-          ) : formMetaData?.published == false ? (
+          ) : metadata?.published == false ? (
             <Button
               className={styles.optionButtons}
               onClick={() => handlePublishState("publish")}

--- a/src/components/form-editor/modals/edit-question.tsx
+++ b/src/components/form-editor/modals/edit-question.tsx
@@ -6,6 +6,7 @@ import {
   ComposedModal,
   Form,
   FormGroup,
+  InlineNotification,
   ModalBody,
   ModalFooter,
   ModalHeader,
@@ -28,7 +29,7 @@ interface EditQuestionModalProps {
 const EditQuestion: React.FC<EditQuestionModalProps> = ({ question }) => {
   const { t } = useTranslation();
   const [searchConcept, setSearchConcept] = useState("");
-  const { concepts } = useConceptLookup(searchConcept);
+  const { concepts, error } = useConceptLookup(searchConcept);
   const { schema, setSchema } = useContext(SchemaContext);
   const { questionTypes } = useConfig();
   const { renderElements } = useConfig();
@@ -329,6 +330,19 @@ const EditQuestion: React.FC<EditQuestionModalProps> = ({ question }) => {
                   onChange={(event) => setQuestionId(event.target.value)}
                   required
                 />
+                {error ? (
+                  <InlineNotification
+                    style={{
+                      minWidth: "100%",
+                      margin: "0rem",
+                      padding: "0rem",
+                    }}
+                    kind={"error"}
+                    lowContrast
+                    subtitle={t("searchError", `${error?.message}`)}
+                    title={t("searchError", "Error searching for concepts")}
+                  />
+                ) : null}
                 {renderElement !== "ui-select-extended" ? (
                   concept === null ? (
                     <ComboBox

--- a/src/components/form-editor/modals/new-question.tsx
+++ b/src/components/form-editor/modals/new-question.tsx
@@ -6,6 +6,7 @@ import {
   ComposedModal,
   Form,
   FormGroup,
+  InlineNotification,
   ModalBody,
   ModalFooter,
   ModalHeader,
@@ -27,7 +28,7 @@ interface CreateQuestionModalProps {
 const CreateQuestion: React.FC<CreateQuestionModalProps> = ({ questions }) => {
   const { t } = useTranslation();
   const [searchConcept, setSearchConcept] = useState("");
-  const { concepts } = useConceptLookup(searchConcept);
+  const { concepts, error } = useConceptLookup(searchConcept);
   const { schema, setSchema } = useContext(SchemaContext);
   const { questionTypes } = useConfig();
   const { renderElements } = useConfig();
@@ -247,6 +248,19 @@ const CreateQuestion: React.FC<CreateQuestionModalProps> = ({ questions }) => {
                   onChange={(event) => setQuestionId(event.target.value)}
                   required
                 />
+                {error ? (
+                  <InlineNotification
+                    style={{
+                      minWidth: "100%",
+                      margin: "0rem",
+                      padding: "0rem",
+                    }}
+                    kind={"error"}
+                    lowContrast
+                    subtitle={t("searchError", `${error?.message}`)}
+                    title={t("searchError", "Error searching for concepts")}
+                  />
+                ) : null}
                 {renderElement !== "ui-select-extended" ? (
                   <ComboBox
                     onChange={(event) => {

--- a/src/hooks/useConceptLookup.ts
+++ b/src/hooks/useConceptLookup.ts
@@ -1,21 +1,18 @@
 import useSWR from "swr";
-import { openmrsFetch, showToast } from "@openmrs/esm-framework";
+import { openmrsFetch } from "@openmrs/esm-framework";
 import { Concept } from "../types";
 
-export function useConceptLookup(conceptID) {
-  const url =
-    conceptID != "" ? `/ws/rest/v1/concept?q=${conceptID}&v=full` : null;
+export function useConceptLookup(conceptId: string) {
+  const url = `/ws/rest/v1/concept?q=${conceptId}&v=full`;
+
   const { data, error } = useSWR<{ data: { results: Array<Concept> } }, Error>(
-    url,
+    conceptId ? url : null,
     openmrsFetch
   );
-  if (error) {
-    showToast({
-      title: "Error",
-      kind: "error",
-      critical: true,
-      description: `${error.message}`,
-    });
-  }
-  return { concepts: data?.data?.results ?? [] };
+
+  return {
+    concepts: data?.data?.results ?? [],
+    error: error,
+    isLoading: !data && !error,
+  };
 }

--- a/src/hooks/useFormMetadata.ts
+++ b/src/hooks/useFormMetadata.ts
@@ -1,30 +1,18 @@
 import useSWRImmutable from "swr/immutable";
-import { openmrsFetch, showToast } from "@openmrs/esm-framework";
+import { openmrsFetch } from "@openmrs/esm-framework";
 import { Form } from "../types";
 
 export const useFormMetadata = (uuid: string) => {
-  const url = uuid == "new" ? null : `/ws/rest/v1/form/${uuid}?v=full`;
+  const url = `/ws/rest/v1/form/${uuid}?v=full`;
+
   const { data, error } = useSWRImmutable<{ data: Form }, Error>(
-    url,
+    uuid === "new" ? null : url,
     openmrsFetch
   );
 
-  if (error) {
-    showToast({
-      title: "Error",
-      kind: "error",
-      critical: true,
-      description: `${error.message}`,
-    });
-  }
-
-  if (uuid == "new") {
-    return {
-      formMetaData: null,
-    };
-  } else {
-    return {
-      formMetaData: data?.data,
-    };
-  }
+  return {
+    metadata: data?.data,
+    error: error,
+    isLoading: !data && !error,
+  };
 };


### PR DESCRIPTION
Moves error rendering logic from hooks to components. The custom hooks should only be concerned with fetching data, and not rendering error messages in the UI. Also renames a few variables.