### PR TITLE
(refactor) Refactor useFormMetadata hook

### DIFF
--- a/src/components/form-editor/form-editor.tsx
+++ b/src/components/form-editor/form-editor.tsx
@@ -18,7 +18,7 @@ import SaveForm from "./modals/save-form";
 import { showToast } from "@openmrs/esm-framework";
 import { SchemaContext } from "../../context/context";
 import { useClobdata } from "../../hooks/useClobdata";
-import { useFormMetadata } from "../../hooks/useFormMetadata";
+import { useForm } from "../../hooks/useForm";
 import { publish, unpublish } from "../../forms.resource";
 import ElementEditor from "./element-editor/element-editor";
 import FormRenderer from "./form-renderer/form-renderer";
@@ -46,14 +46,14 @@ const Error = ({ error, title }) => {
 const FormEditor: React.FC = () => {
   const { t } = useTranslation();
   const { uuid } = useParams<Route>();
-  const { metadata } = useFormMetadata(uuid);
-  const { clobdata, clobdataError, isLoadingClobdata } = useClobdata(metadata);
+  const { form, formError, isLoadingForm } = useForm(uuid);
+  const { clobdata, clobdataError, isLoadingClobdata } = useClobdata(form);
   const [schema, setSchema] = useState<any>();
 
   const handlePublishState = async (option) => {
     if (option == "publish") {
       try {
-        await publish(metadata?.uuid);
+        await publish(form?.uuid);
         showToast({
           title: t("success", "Success!"),
           kind: "success",
@@ -70,7 +70,7 @@ const FormEditor: React.FC = () => {
       }
     } else if (option == "unpublish") {
       try {
-        await unpublish(metadata?.uuid);
+        await unpublish(form?.uuid);
         showToast({
           title: t("success", "Success!"),
           kind: "success",
@@ -99,8 +99,8 @@ const FormEditor: React.FC = () => {
     <SchemaContext.Provider value={{ schema, setSchema }}>
       <div className={styles.wrapContainer}>
         <div className={styles.actionsContainer}>
-          <SaveForm form={metadata} />
-          {metadata?.published == true ? (
+          <SaveForm form={form} />
+          {form?.published == true ? (
             <Button
               className={styles.optionButtons}
               onClick={() => handlePublishState("unpublish")}
@@ -108,7 +108,7 @@ const FormEditor: React.FC = () => {
             >
               {t("unpublishForm", "Unpublish form")}
             </Button>
-          ) : metadata?.published == false ? (
+          ) : form?.published == false ? (
             <Button
               className={styles.optionButtons}
               onClick={() => handlePublishState("publish")}
@@ -132,6 +132,12 @@ const FormEditor: React.FC = () => {
               <TabPanels>
                 <TabPanel>
                   <>
+                    {formError ? (
+                      <Error
+                        error={formError}
+                        title={t("formError", "Error loading form metadata")}
+                      />
+                    ) : null}
                     {clobdataError ? (
                       <Error
                         error={clobdataError}

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -2,17 +2,17 @@ import useSWRImmutable from "swr/immutable";
 import { openmrsFetch } from "@openmrs/esm-framework";
 import { Form } from "../types";
 
-export const useFormMetadata = (uuid: string) => {
+export const useForm = (uuid: string) => {
   const url = `/ws/rest/v1/form/${uuid}?v=full`;
 
   const { data, error } = useSWRImmutable<{ data: Form }, Error>(
-    uuid === "new" ? null : url,
+    uuid ? url : null,
     openmrsFetch
   );
 
   return {
-    metadata: data?.data,
-    error: error,
-    isLoading: !data && !error,
+    form: data?.data,
+    formError: error,
+    isLoadingForm: !data && !error,
   };
 };


### PR DESCRIPTION
Refactors the useForm hook as follows:

- Renames it from `useFormMetadata` to `useForm`.
- Renames the hook's return values to better communicate their intent.
- Moves the error notification UI concerns to the component. The hook should only be concerned with data fetching logic.