### PR TITLE
(chore) Move Git hooks into husky dir

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+yarn pretty-quick --staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,6 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+set -e  # die on error
+
+yarn verify

--- a/package.json
+++ b/package.json
@@ -19,12 +19,6 @@
     "coverage": "yarn test --coverage --passWithNoTests",
     "prepare": "husky install"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "pretty-quick --staged",
-      "pre-push": "yarn verify"
-    }
-  },
   "browserslist": [
     "extends browserslist-config-openmrs"
   ],


### PR DESCRIPTION
As shown in the [husky docs](https://typicode.github.io/husky/#/).