### PR TITLE
(feat) Use props instead of context for state management

### DIFF
--- a/src/components/form-editor/element-editor/element-editor.tsx
+++ b/src/components/form-editor/element-editor/element-editor.tsx
@@ -1,16 +1,22 @@
-import React, { useContext, useEffect, useState } from "react";
-import { Accordion, Button, Column, Row, TextInput } from "@carbon/react";
+import React, { useEffect, useState } from "react";
+import { Accordion, Button, TextInput } from "@carbon/react";
 import { Schema } from "../../../types";
-import { SchemaContext } from "../../../context/context";
 import PageElement from "./elements/page";
 import styles from "./element-editor.scss";
 import { Checkmark } from "@carbon/react/icons";
 import CreatePage from "../modals/new-page";
 import { useTranslation } from "react-i18next";
 
-const ElementEditor: React.FC = () => {
+type ElementEditorProps = {
+  schema: Schema;
+  onSchemaUpdate: (schema: Schema) => void;
+};
+
+const ElementEditor: React.FC<ElementEditorProps> = ({
+  schema,
+  onSchemaUpdate,
+}) => {
   const { t } = useTranslation();
-  const { schema, setSchema } = useContext(SchemaContext);
   const [formSchema, setFormSchema] = useState<Schema>();
   const [schemaName, setSchemaName] = useState("");
 
@@ -19,15 +25,15 @@ const ElementEditor: React.FC = () => {
   useEffect(() => {
     setFormSchema(schema);
     setSchemaName(name);
-  }, [schema]);
+  }, [name, schema]);
 
   const deletePage = (index) => {
     pages.splice(index, 1);
-    setSchema({ ...schema });
+    onSchemaUpdate({ ...schema });
   };
 
   const updateSchemaName = () => {
-    setSchema({ ...schema, name: schemaName });
+    onSchemaUpdate({ ...schema, name: schemaName });
   };
 
   return (
@@ -57,15 +63,21 @@ const ElementEditor: React.FC = () => {
         />
       </div>
       <h5>{t("pages", "Pages")}</h5>
-      <CreatePage pages={pages} />
+      <CreatePage
+        pages={pages}
+        schema={schema}
+        onSchemaUpdate={onSchemaUpdate}
+      />
       <Accordion>
         {pages
           ? pages.map((page, key) => (
               <PageElement
+                key={key}
                 page={page}
                 index={key}
                 deletePage={deletePage}
-                key={key}
+                onSchemaUpdate={onSchemaUpdate}
+                schema={schema}
               />
             ))
           : null}

--- a/src/components/form-editor/element-editor/elements/page.tsx
+++ b/src/components/form-editor/element-editor/elements/page.tsx
@@ -1,10 +1,9 @@
-import React, { useContext } from "react";
+import React from "react";
 import { AccordionItem, Button, Column, Row } from "@carbon/react";
-import { Page } from "../../../../types";
+import { Page, Schema } from "../../../../types";
 import SectionElement from "./section";
 import styles from "./elements.scss";
 import { TrashCan } from "@carbon/react/icons";
-import { SchemaContext } from "../../../../context/context";
 import { useTranslation } from "react-i18next";
 import EditPage from "../../modals/edit-page";
 import CreateSection from "../../modals/new-section";
@@ -13,19 +12,23 @@ interface PageElementProps {
   page: Page;
   index: any;
   deletePage: (index: number) => void;
+  schema: Schema;
+  onSchemaUpdate: (schema: Schema) => void;
 }
 
 const PageElement: React.FC<PageElementProps> = ({
   page,
   index,
   deletePage,
+  schema,
+  onSchemaUpdate,
 }) => {
   const { t } = useTranslation();
-  const { schema, setSchema } = useContext(SchemaContext);
   const deleteSection = (index) => {
     page.sections.splice(index, 1);
-    setSchema({ ...schema });
+    onSchemaUpdate({ ...schema });
   };
+
   return (
     <div>
       <Row>
@@ -39,7 +42,11 @@ const PageElement: React.FC<PageElementProps> = ({
                   </div>
                 </Column>
                 <Column>
-                  <CreateSection sections={page.sections} />
+                  <CreateSection
+                    sections={page.sections}
+                    schema={schema}
+                    onSchemaUpdate={onSchemaUpdate}
+                  />
                 </Column>
               </Row>
               {page.sections
@@ -49,6 +56,8 @@ const PageElement: React.FC<PageElementProps> = ({
                       key={key}
                       index={key}
                       deleteSection={deleteSection}
+                      schema={schema}
+                      onSchemaUpdate={onSchemaUpdate}
                     />
                   ))
                 : null}
@@ -56,7 +65,11 @@ const PageElement: React.FC<PageElementProps> = ({
           </AccordionItem>
         </Column>
         <Column sm={1} md={1} lg={2} className={styles.pageOptionsColumn}>
-          <EditPage page={page} />
+          <EditPage
+            page={page}
+            schema={schema}
+            onSchemaUpdate={onSchemaUpdate}
+          />
           <Button
             size="sm"
             renderIcon={TrashCan}

--- a/src/components/form-editor/element-editor/elements/question.tsx
+++ b/src/components/form-editor/element-editor/elements/question.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { TrashCan } from "@carbon/react/icons";
 import { Button, Column, Row } from "@carbon/react";
-import { Question } from "../../../../types";
+import { Question, Schema } from "../../../../types";
 import EditQuestion from "../../modals/edit-question";
 import styles from "./elements.scss";
 
@@ -9,12 +9,16 @@ interface QuestionElementProps {
   question: Question;
   index: any;
   deleteQuestion: (index: number) => void;
+  schema: Schema;
+  onSchemaUpdate: (schema: Schema) => void;
 }
 
 const QuestionElement: React.FC<QuestionElementProps> = ({
   question,
   index,
   deleteQuestion,
+  schema,
+  onSchemaUpdate,
 }) => {
   return (
     <div className={styles.questionWrap}>
@@ -23,7 +27,11 @@ const QuestionElement: React.FC<QuestionElementProps> = ({
           <div className={styles.questionLabel}>{question.label}</div>
         </Column>
         <Column>
-          <EditQuestion question={question} />
+          <EditQuestion
+            question={question}
+            schema={schema}
+            onSchemaUpdate={onSchemaUpdate}
+          />
           <Button
             size="sm"
             renderIcon={TrashCan}

--- a/src/components/form-editor/element-editor/elements/section.tsx
+++ b/src/components/form-editor/element-editor/elements/section.tsx
@@ -1,8 +1,7 @@
-import React, { useContext } from "react";
+import React from "react";
 import { TrashCan } from "@carbon/react/icons";
 import { Button, Column, Row } from "@carbon/react";
-import { Section } from "../../../../types";
-import { SchemaContext } from "../../../../context/context";
+import { Section, Schema } from "../../../../types";
 import EditSection from "../../modals/edit-section";
 import CreateQuestion from "../../modals/new-question";
 import styles from "./elements.scss";
@@ -13,19 +12,23 @@ interface SectionElementProps {
   section: Section;
   index: number;
   deleteSection: (index: number) => void;
+  schema: Schema;
+  onSchemaUpdate: (schema: Schema) => void;
 }
 
 const SectionElement: React.FC<SectionElementProps> = ({
   section,
   index,
   deleteSection,
+  schema,
+  onSchemaUpdate,
 }) => {
   const { t } = useTranslation();
-  const { schema, setSchema } = useContext(SchemaContext);
   const deleteQuestion = (index) => {
     section.questions.splice(index, 1);
-    setSchema({ ...schema });
+    onSchemaUpdate({ ...schema });
   };
+
   return (
     <div className={styles.sectionWrap}>
       <Row className={styles.sectionRow}>
@@ -33,7 +36,11 @@ const SectionElement: React.FC<SectionElementProps> = ({
           <h4>{section.label}</h4>
         </Column>
         <Column>
-          <EditSection section={section} />
+          <EditSection
+            section={section}
+            schema={schema}
+            onSchemaUpdate={onSchemaUpdate}
+          />
           <Button
             size="sm"
             renderIcon={TrashCan}
@@ -51,16 +58,22 @@ const SectionElement: React.FC<SectionElementProps> = ({
           <h5>{t("questions", "Questions")}</h5>
         </Column>
         <Column>
-          <CreateQuestion questions={section.questions} />
+          <CreateQuestion
+            questions={section.questions}
+            schema={schema}
+            onSchemaUpdate={onSchemaUpdate}
+          />
         </Column>
       </Row>
       {section.questions
         ? section.questions.map((question, key) => (
             <QuestionElement
+              key={key}
               question={question}
               index={key}
               deleteQuestion={deleteQuestion}
-              key={key}
+              schema={schema}
+              onSchemaUpdate={onSchemaUpdate}
             />
           ))
         : null}

--- a/src/components/form-editor/form-renderer/form-renderer.tsx
+++ b/src/components/form-editor/form-renderer/form-renderer.tsx
@@ -1,10 +1,18 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { OHRIForm } from "@ohri/openmrs-ohri-form-engine-lib";
 import { OHRIFormSchema } from "@ohri/openmrs-ohri-form-engine-lib/src/api/types";
-import { SchemaContext } from "../../../context/context";
 import { useConfig } from "@openmrs/esm-framework";
+import { Schema } from "../../../types";
 
-const FormRenderer: React.FC = () => {
+type FormRendererProps = {
+  onSchemaUpdate: (schema: Schema) => void;
+  schema: Schema;
+};
+
+const FormRenderer: React.FC<FormRendererProps> = ({
+  onSchemaUpdate,
+  schema,
+}) => {
   const { patientUuidConfig } = useConfig();
   const defaultSchema: OHRIFormSchema = {
     name: "",
@@ -16,7 +24,6 @@ const FormRenderer: React.FC = () => {
   };
   const patientUUID = patientUuidConfig;
   const [currentFormMode, setCurrentFormMode] = useState<any>("enter");
-  const { schema, setSchema } = useContext(SchemaContext);
   const [renderFormSchema, setRenderFormSchema] =
     useState<OHRIFormSchema>(defaultSchema);
   useEffect(() => {

--- a/src/components/form-editor/modals/edit-page.tsx
+++ b/src/components/form-editor/modals/edit-page.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Button,
@@ -10,18 +10,22 @@ import {
   ModalHeader,
   TextInput,
 } from "@carbon/react";
-import { Page } from "../../../types";
+import { Page, Schema } from "../../../types";
 import { Edit } from "@carbon/react/icons";
-import { SchemaContext } from "../../../context/context";
 import { showToast } from "@openmrs/esm-framework";
 
 interface EditPageModalProps {
   page: Page;
+  schema: Schema;
+  onSchemaUpdate: (schema: Schema) => void;
 }
 
-const EditPage: React.FC<EditPageModalProps> = ({ page }) => {
+const EditPage: React.FC<EditPageModalProps> = ({
+  page,
+  schema,
+  onSchemaUpdate,
+}) => {
   const { t } = useTranslation();
-  const { schema, setSchema } = useContext(SchemaContext);
   const [openEditPageModal, setOpenEditPageModal] = useState(false);
   const [pageName, setPageName] = useState("");
 
@@ -34,7 +38,7 @@ const EditPage: React.FC<EditPageModalProps> = ({ page }) => {
     let pageName = event.target.pageName.value;
     try {
       page.label = pageName == "" ? page.label : pageName;
-      setSchema({ ...schema });
+      onSchemaUpdate({ ...schema });
       showToast({
         title: t("success", "Success!"),
         kind: "success",

--- a/src/components/form-editor/modals/edit-question.tsx
+++ b/src/components/form-editor/modals/edit-question.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Button,
@@ -17,20 +17,30 @@ import {
 } from "@carbon/react";
 import { Edit, TrashCan } from "@carbon/react/icons";
 import { showToast, useConfig } from "@openmrs/esm-framework";
-import { SchemaContext } from "../../../context/context";
-import { Answer, Concept, ConceptMapping, Question } from "../../../types";
+import {
+  Answer,
+  Concept,
+  ConceptMapping,
+  Question,
+  Schema,
+} from "../../../types";
 import { useConceptLookup } from "../../../hooks/useConceptLookup";
 import styles from "./modals.scss";
 
 interface EditQuestionModalProps {
   question: Question;
+  schema: Schema;
+  onSchemaUpdate: (schema: Schema) => void;
 }
 
-const EditQuestion: React.FC<EditQuestionModalProps> = ({ question }) => {
+const EditQuestion: React.FC<EditQuestionModalProps> = ({
+  question,
+  schema,
+  onSchemaUpdate,
+}) => {
   const { t } = useTranslation();
   const [searchConcept, setSearchConcept] = useState("");
   const { concepts, error } = useConceptLookup(searchConcept);
-  const { schema, setSchema } = useContext(SchemaContext);
   const { questionTypes } = useConfig();
   const { renderElements } = useConfig();
   const [openEditQuestionModal, setOpenEditQuestionModal] = useState(false);
@@ -216,7 +226,7 @@ const EditQuestion: React.FC<EditQuestionModalProps> = ({ question }) => {
             break;
         }
       }
-      setSchema({ ...schema });
+      onSchemaUpdate({ ...schema });
       showToast({
         title: t("success", "Success!"),
         kind: "success",

--- a/src/components/form-editor/modals/edit-section.tsx
+++ b/src/components/form-editor/modals/edit-section.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Button,
@@ -11,20 +11,23 @@ import {
   Select,
   SelectItem,
   TextInput,
-  Toggle,
 } from "@carbon/react";
-import { Section } from "../../../types";
+import { Schema, Section } from "../../../types";
 import { Edit } from "@carbon/react/icons";
-import { SchemaContext } from "../../../context/context";
 import { showToast } from "@openmrs/esm-framework";
 
 interface EditSectionModalProps {
   section: Section;
+  schema: Schema;
+  onSchemaUpdate: (schema: Schema) => void;
 }
 
-const EditSection: React.FC<EditSectionModalProps> = ({ section }) => {
+const EditSection: React.FC<EditSectionModalProps> = ({
+  section,
+  schema,
+  onSchemaUpdate,
+}) => {
   const { t } = useTranslation();
-  const { schema, setSchema } = useContext(SchemaContext);
   const [openEditSectionModal, setOpenEditSectionModal] = useState(false);
   const [sectionName, setSectionName] = useState("");
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
@@ -43,7 +46,7 @@ const EditSection: React.FC<EditSectionModalProps> = ({ section }) => {
     try {
       section.label = sectionName;
       section.isExpanded = isExpanded ? "true" : "false";
-      setSchema({ ...schema });
+      onSchemaUpdate({ ...schema });
       showToast({
         title: t("success", "Success!"),
         kind: "success",

--- a/src/components/form-editor/modals/new-page.tsx
+++ b/src/components/form-editor/modals/new-page.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Button,
@@ -10,19 +10,23 @@ import {
   ModalHeader,
   TextInput,
 } from "@carbon/react";
-import { Page } from "../../../types";
+import { Page, Schema } from "../../../types";
 import { Add } from "@carbon/react/icons";
-import { SchemaContext } from "../../../context/context";
 import { showToast } from "@openmrs/esm-framework";
 import styles from "./modals.scss";
 
 interface NewPageModalProps {
   pages: Array<Page>;
+  schema: Schema;
+  onSchemaUpdate: (schema: Schema) => void;
 }
 
-const CreatePage: React.FC<NewPageModalProps> = ({ pages }) => {
+const CreatePage: React.FC<NewPageModalProps> = ({
+  pages,
+  schema,
+  onSchemaUpdate,
+}) => {
   const { t } = useTranslation();
-  const { schema, setSchema } = useContext(SchemaContext);
   const [openCreatePageModal, setOpenCreatePageModal] = useState(false);
   const [pageName, setPageName] = useState("");
 
@@ -31,7 +35,7 @@ const CreatePage: React.FC<NewPageModalProps> = ({ pages }) => {
     const newPage: Page = { label: pageName, sections: [] };
     try {
       pages.push(newPage);
-      setSchema({ ...schema });
+      onSchemaUpdate({ ...schema });
       showToast({
         title: t("success", "Success!"),
         kind: "success",

--- a/src/components/form-editor/modals/new-question.tsx
+++ b/src/components/form-editor/modals/new-question.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Button,
@@ -14,22 +14,32 @@ import {
   SelectItem,
   TextInput,
 } from "@carbon/react";
-import { Answer, Concept, ConceptMapping, Question } from "../../../types";
+import {
+  Answer,
+  Concept,
+  ConceptMapping,
+  Question,
+  Schema,
+} from "../../../types";
 import { Add } from "@carbon/react/icons";
-import { SchemaContext } from "../../../context/context";
 import { showToast, useConfig } from "@openmrs/esm-framework";
 import { useConceptLookup } from "../../../hooks/useConceptLookup";
 import styles from "./modals.scss";
 
 interface CreateQuestionModalProps {
   questions: any;
+  schema: Schema;
+  onSchemaUpdate: (schema: Schema) => void;
 }
 
-const CreateQuestion: React.FC<CreateQuestionModalProps> = ({ questions }) => {
+const CreateQuestion: React.FC<CreateQuestionModalProps> = ({
+  questions,
+  schema,
+  onSchemaUpdate,
+}) => {
   const { t } = useTranslation();
   const [searchConcept, setSearchConcept] = useState("");
   const { concepts, error } = useConceptLookup(searchConcept);
-  const { schema, setSchema } = useContext(SchemaContext);
   const { questionTypes } = useConfig();
   const { renderElements } = useConfig();
   const [openCreateQuestionModal, setOpenCreateQuestionModal] = useState(false);
@@ -134,7 +144,7 @@ const CreateQuestion: React.FC<CreateQuestionModalProps> = ({ questions }) => {
           break;
       }
       questions.push(newQuestion);
-      setSchema({ ...schema });
+      onSchemaUpdate({ ...schema });
       showToast({
         title: t("success", "Success!"),
         kind: "success",

--- a/src/components/form-editor/modals/new-section.tsx
+++ b/src/components/form-editor/modals/new-section.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Button,
@@ -12,18 +12,22 @@ import {
   SelectItem,
   TextInput,
 } from "@carbon/react";
-import { Section } from "../../../types";
+import { Section, Schema } from "../../../types";
 import { Add } from "@carbon/react/icons";
-import { SchemaContext } from "../../../context/context";
 import { showToast } from "@openmrs/esm-framework";
 
 interface CreateSectionModalProps {
   sections: Array<Section>;
+  schema: Schema;
+  onSchemaUpdate: (schema: Schema) => void;
 }
 
-const CreateSection: React.FC<CreateSectionModalProps> = ({ sections }) => {
+const CreateSection: React.FC<CreateSectionModalProps> = ({
+  sections,
+  schema,
+  onSchemaUpdate,
+}) => {
   const { t } = useTranslation();
-  const { schema, setSchema } = useContext(SchemaContext);
   const [openCreateSectionModal, setOpenCreateSectionModal] = useState(false);
   const [sectionName, setSectionName] = useState("");
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
@@ -37,7 +41,7 @@ const CreateSection: React.FC<CreateSectionModalProps> = ({ sections }) => {
     };
     try {
       sections.push(newSection);
-      setSchema({ ...schema });
+      onSchemaUpdate({ ...schema });
       showToast({
         title: t("success", "Success!"),
         kind: "success",

--- a/src/components/form-editor/modals/save-form.tsx
+++ b/src/components/form-editor/modals/save-form.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState } from "react";
+import React, { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import styles from "./../form-editor.scss";
 import {
@@ -14,7 +14,7 @@ import {
   TextArea,
   TextInput,
 } from "@carbon/react";
-import { EncounterType, Resource } from "../../../types";
+import { EncounterType, Resource, Schema } from "../../../types";
 import { useEncounterTypes } from "../../../hooks/useEncounterTypes";
 import {
   uploadSchema,
@@ -28,10 +28,10 @@ import {
   updateEncounterType,
 } from "../../../forms.resource";
 import { showToast } from "@openmrs/esm-framework";
-import { SchemaContext } from "../../../context/context";
 
 interface SaveFormModalProps {
   form: FormGroupData;
+  schema: Schema;
 }
 
 interface FormGroupData {
@@ -43,13 +43,13 @@ interface FormGroupData {
   resources: Array<Resource>;
 }
 
-const SaveForm: React.FC<SaveFormModalProps> = ({ form }) => {
+const SaveForm: React.FC<SaveFormModalProps> = ({ form, schema }) => {
   const { t } = useTranslation();
   const { encounterTypes, encounterTypesError } = useEncounterTypes();
   const [openSaveFormModal, setOpenSaveFormModal] = useState(false);
   const [openConfirmSaveModal, setOpenConfirmSaveModal] = useState(false);
   const [saveState, setSaveState] = useState("");
-  const { schema, setSchema } = useContext(SchemaContext);
+  const [formSchema, setFormSchema] = useState<string>("");
 
   const openModal = useCallback((option) => {
     if (option === "newVersion") {

--- a/src/components/form-editor/schema-editor/schema-editor.component.tsx
+++ b/src/components/form-editor/schema-editor/schema-editor.component.tsx
@@ -1,31 +1,45 @@
-import React, { useCallback, useContext, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { Button } from "@carbon/react";
 import styles from "./schema-editor.scss";
 import AceEditor from "react-ace";
 import "ace-builds/webpack-resolver";
 import { useTranslation } from "react-i18next";
-import { SchemaContext } from "../../../context/context";
+import { Schema } from "../../../types";
 
-const SchemaEditorComponent: React.FC = () => {
+type SchemaEditorProps = {
+  isLoading: boolean;
+  onSchemaUpdate: (schema: Schema) => void;
+  schema: Schema;
+};
+
+const SchemaEditorComponent: React.FC<SchemaEditorProps> = ({
+  isLoading,
+  onSchemaUpdate,
+  schema,
+}) => {
   const { t } = useTranslation();
-  const { schema, setSchema } = useContext(SchemaContext);
   const [formSchema, setFormSchema] = useState<string>("");
   const [errorMessage, setErrorMessage] = useState("");
+
+  useEffect(() => {
+    const stringifiedSchema = JSON.stringify(schema, null, 2);
+    setFormSchema(stringifiedSchema);
+  }, [schema]);
+
+  const handleSchemaChange = (updatedSchema: string) => {
+    setFormSchema(updatedSchema);
+  };
 
   const render = useCallback(() => {
     setErrorMessage("");
     try {
       let parsedJson = JSON.parse(formSchema);
+      onSchemaUpdate(parsedJson);
       setFormSchema(JSON.stringify(parsedJson, null, 2));
-      setSchema(parsedJson);
     } catch (error) {
       setErrorMessage(error.message);
     }
-  }, [formSchema, setSchema]);
-
-  useEffect(() => {
-    setFormSchema(JSON.stringify(schema, null, 2));
-  }, [schema]);
+  }, [formSchema, onSchemaUpdate]);
 
   return (
     <div>
@@ -37,7 +51,7 @@ const SchemaEditorComponent: React.FC = () => {
         mode="json"
         theme="github"
         name="schemaEditor"
-        onChange={(value) => setFormSchema(value)}
+        onChange={handleSchemaChange}
         fontSize={14}
         showPrintMargin={true}
         showGutter={true}

--- a/src/context/context.tsx
+++ b/src/context/context.tsx
@@ -1,4 +1,0 @@
-import { createContext } from "react";
-import { SchemaContextType } from "../types";
-
-export const SchemaContext = createContext<SchemaContextType>(null);


### PR DESCRIPTION
This PR migrates the state management approach used in this repo from context to props. Whilst it's tempting to reach for context to manage state, I think this application's state management needs [do not merit](https://beta.reactjs.org/learn/passing-data-deeply-with-context#before-you-use-context) using context. 

The significant benefit of using props is that they make data flow explicit, which can help with maintainability. A common concern when passing props is the dreaded [prop-drilling](https://kentcdodds.com/blog/prop-drilling) problem. I don't think that's a problem here because all the components that receive the props use them (rather than only passing them further down).

### Further reading

- https://kentcdodds.com/blog/application-state-management-with-react
- https://kentcdodds.com/blog/how-to-use-react-context-effectively

Note, however, that this is a strong view that is weakly held. I'm very open to alternative arguments.