### PR TITLE
(fix) Amend patientUuid config property

### DIFF
--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -37,9 +37,10 @@ export const configSchema = {
       "problem",
     ],
   },
-  patientUuidConfig: {
+  patientUuid: {
     _type: "String",
-    _default: "b280078a-c0ce-443b-9997-3c66c63ec2f8",
-    _description: "Patient UUID used to render form preview",
+    _default: "88f1032f-adae-4ef2-9025-2c40b71dd897",
+    _description:
+      "UUID of the test patient whose information gets rendered in a patient banner within the form renderer",
   },
 };


### PR DESCRIPTION
Amends the `patientUuid` config property as follows:

- Renames the property from `patientUuidConfig` to just `patientUuid`.
- Changes the default UUID to that of an existing test patient on the dev3 server.
- Updates the property description to accurately represent what it actually does.