### PR TITLE
(feat) Schema editor UI improvements

### DIFF
--- a/src/components/schema-editor/schema-editor.scss
+++ b/src/components/schema-editor/schema-editor.scss
@@ -1,12 +1,26 @@
-.renderButton {
-  margin-top: 1rem;
+@use '@carbon/styles/scss/colors';
+@use '@carbon/styles/scss/type';
+
+.actionButtons {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  margin: 1rem 0;
+
+  button {
+    margin-left: 1rem
+  }
 }
 
-.inputErrorMessage {
-  padding: 10px 0 15px 0;
-  color: red;
+.errorMessage {
+  @include type.type-style("label-02");
+  background-color: colors.$red-20;
+  color: colors.$red-70;
+  padding: 1.5rem;
+  margin: 1rem 0;
 }
 
-.aceEditor {
-  width: 100%!important;
+.heading {
+  @include type.type-style('heading-compact-02');
+  margin-bottom: 1rem;
 }


### PR DESCRIPTION
This PR provides the following improvements to the schema editor:

- Show a loading state when an existing schema is getting loaded into the schema editor.
- Add a button that allows the user to input a dummy schema into the editor.
- Make the following changes to the embedded editor's config:
  - Remove print margins.
  - Make the editor window span the full viewport height and width.
  - Bump the font size one point up to 15px.
  - Change the editor theme to `textmate`.