### PR TITLE
(fix) Remove POC prefix requirement and modify useForm hook

### DIFF
--- a/src/components/dashboard/dashboard.component.tsx
+++ b/src/components/dashboard/dashboard.component.tsx
@@ -24,7 +24,7 @@ import { navigate, useLayoutType } from "@openmrs/esm-framework";
 
 import { FilterProps } from "../../types";
 import { useClobdata } from "../../hooks/useClobdata";
-import { usePocForms } from "../../hooks/usePocForms";
+import { useForms } from "../../hooks/useForms";
 import EmptyState from "../empty-state/empty-state.component";
 import ErrorState from "../error-state/error-state.component";
 import styles from "./dashboard.scss";
@@ -283,7 +283,7 @@ function FormsList({ forms, isValidating, t }) {
 
 const Dashboard: React.FC = () => {
   const { t } = useTranslation();
-  const { error, forms, isLoading, isValidating } = usePocForms();
+  const { error, forms, isLoading, isValidating } = useForms();
 
   return (
     <div className={styles.container}>

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -1,11 +1,11 @@
-import useSWRImmutable from "swr/immutable";
+import useSWR from "swr/immutable";
 import { openmrsFetch } from "@openmrs/esm-framework";
 import { Form } from "../types";
 
 export const useForm = (uuid: string) => {
   const FORM_URL = `/ws/rest/v1/form/${uuid}?v=full`;
 
-  const { data, error } = useSWRImmutable<{ data: Form }, Error>(
+  const { data, error } = useSWR<{ data: Form }, Error>(
     uuid ? FORM_URL : null,
     openmrsFetch
   );

--- a/src/hooks/useForms.ts
+++ b/src/hooks/useForms.ts
@@ -2,9 +2,9 @@ import useSWR from "swr";
 import { openmrsFetch } from "@openmrs/esm-framework";
 import { Form } from "../types";
 
-export function usePocForms() {
+export function useForms() {
   const FORMS_URL =
-    "/ws/rest/v1/form?q=POC&v=custom:(uuid,name,encounterType:(uuid,name),version,published,retired,resources:(uuid,name,dataType,valueReference))";
+    "/ws/rest/v1/form?v=custom:(uuid,name,encounterType:(uuid,name),version,published,retired,resources:(uuid,name,dataType,valueReference))";
 
   const { data, error, isValidating } = useSWR<
     { data: { results: Array<Form> } },


### PR DESCRIPTION
This PR makes a few adjustments to some custom hooks. More specifically:

-  Renames the `usePocForms` hook to `useForms` and alters the fetcher key, omitting the `POC` parameter. The reasons behind the requirement for forms to match the `POC` keyword are historical and likely no longer relevant in our current setup. In any case, none of the forms on the dev3 server meets the POC prefix requirement. 
- Alters the `useForm` hook to leverage `useSWR` instead of `useSWRImmutable` because changes to the form object should be automatically revalidated. 