### PR TITLE
(fix) Fix ace editor console warnings

### DIFF
--- a/src/components/schema-editor/schema-editor.component.tsx
+++ b/src/components/schema-editor/schema-editor.component.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import AceEditor from "react-ace";
 import "ace-builds/webpack-resolver";
+import "ace-builds/src-noconflict/ext-language_tools";
 import { Button, InlineLoading } from "@carbon/react";
 import { useTranslation } from "react-i18next";
 import { OHRIFormSchema } from "@ohri/openmrs-ohri-form-engine-lib";


### PR DESCRIPTION
Fixes a bunch of console warnings from the embedded ace editor by importing the language tools plugin as recommended [here](https://github.com/securingsincity/react-ace/issues/95).

<img width="528" alt="Screenshot 2023-01-02 at 11 32 36" src="https://user-images.githubusercontent.com/8509731/210208643-5d203e69-ff46-46bc-aba9-776ff8bdb6b5.png">
