### PR TITLE
(fix) Fix styling of the error message container

### DIFF
--- a/src/components/schema-editor/schema-editor.component.tsx
+++ b/src/components/schema-editor/schema-editor.component.tsx
@@ -156,7 +156,7 @@ const SchemaEditor: React.FC<SchemaEditorProps> = ({
       </div>
 
       {invalidJsonErrorMessage ? (
-        <div className={styles.errorMessage}>
+        <div className={styles.errorContainer}>
           <p className={styles.heading}>
             {t("schemaError", "There's an error in your schema.")}
           </p>

--- a/src/components/schema-editor/schema-editor.scss
+++ b/src/components/schema-editor/schema-editor.scss
@@ -20,10 +20,6 @@
   margin: 1rem 0;
 }
 
-.errorMessage {
-  @include type.type-style('body-compact-01');
-}
-
 .heading {
   @include type.type-style('heading-compact-02');
   margin-bottom: 1rem;


### PR DESCRIPTION
Fixes the appearance of the error message container that gets shown when the user attempts to render JSON code that is invalid.

## Screenshots
> Before
<img width="908" alt="Screenshot 2023-01-07 at 13 52 12" src="https://user-images.githubusercontent.com/8509731/211146593-d1e3b1b4-a6dd-45f2-8604-286b7241651a.png">

> After
<img width="919" alt="Screenshot 2023-01-07 at 13 50 14" src="https://user-images.githubusercontent.com/8509731/211146534-2220984a-7edb-4796-8e5c-08c429d83eb6.png">
