### PR TITLE
(feat) Display indent guides in schema editor

### DIFF
--- a/src/components/schema-editor/schema-editor.component.tsx
+++ b/src/components/schema-editor/schema-editor.component.tsx
@@ -178,7 +178,7 @@ const SchemaEditor: React.FC<SchemaEditorProps> = ({
         setOptions={{
           enableBasicAutocompletion: false,
           enableLiveAutocompletion: false,
-          displayIndentGuides: false,
+          displayIndentGuides: true,
           enableSnippets: false,
           showLineNumbers: true,
           tabSize: 2,


### PR DESCRIPTION
Restores indent guides in the schema editor, which should help with bracket pair matching and visually parsing code blocks.

<img width="878" alt="Screenshot 2023-01-07 at 14 14 15" src="https://user-images.githubusercontent.com/8509731/211147354-a3213664-c20c-483c-b751-da99bc14d987.png">
