### PR TITLE
(feat) Add the ability to duplicate questions

### DIFF
--- a/src/components/interactive-builder/add-question-modal.component.tsx
+++ b/src/components/interactive-builder/add-question-modal.component.tsx
@@ -173,69 +173,6 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
     }
   };
 
-  const updateQuestion = (questionIndex) => {
-    try {
-      const mappedAnswers = selectedAnswers?.map((answer) => ({
-        concept: answer.id,
-        label: answer.text,
-      }));
-
-      const data = {
-        label: questionLabel ? questionLabel : questionToEdit.label,
-        type: questionType ? questionType : questionToEdit.type,
-        required: isQuestionRequired
-          ? isQuestionRequired
-          : /true/.test(questionToEdit?.required),
-        id: questionId ? questionId : questionToEdit.id,
-        questionOptions: {
-          rendering: fieldType
-            ? fieldType
-            : questionToEdit.questionOptions.rendering,
-          concept: selectedConcept?.uuid
-            ? selectedConcept.uuid
-            : questionToEdit.questionOptions.concept,
-          conceptMappings: conceptMappings.length
-            ? conceptMappings
-            : questionToEdit.questionOptions.conceptMappings,
-          answers: mappedAnswers.length
-            ? mappedAnswers
-            : questionToEdit.questionOptions.answers,
-        },
-      };
-
-      schema.pages[pageIndex].sections[sectionIndex].questions[questionIndex] =
-        data;
-
-      onSchemaChange({ ...schema });
-
-      resetIndices();
-      setQuestionLabel("");
-      setQuestionId("");
-      setIsQuestionRequired(false);
-      setQuestionType(null);
-      setFieldType(null);
-      setSelectedConcept(null);
-      setConceptMappings([]);
-      setAnswers([]);
-      setSelectedAnswers([]);
-      onQuestionEdit(null);
-
-      showToast({
-        title: t("success", "Success!"),
-        kind: "success",
-        critical: true,
-        description: t("questionUpdated", "Question updated"),
-      });
-    } catch (error) {
-      showNotification({
-        title: t("errorUpdatingQuestion", "Error updating question"),
-        kind: "error",
-        critical: true,
-        description: error?.message,
-      });
-    }
-  };
-
   return (
     <ComposedModal open={showModal} onClose={() => onModalChange(false)}>
       <ModalHeader title={t("createNewQuestion", "Create a new question")} />

--- a/src/components/interactive-builder/editable-value.component.tsx
+++ b/src/components/interactive-builder/editable-value.component.tsx
@@ -47,6 +47,7 @@ const EditableValue: React.FC<EditableValueProps> = ({
           <Button
             kind="ghost"
             size="sm"
+            enterDelayMs={200}
             iconDescription={t("editButton", "Edit {elementType}", {
               elementType: elementType,
             })}

--- a/src/components/interactive-builder/interactive-builder.component.tsx
+++ b/src/components/interactive-builder/interactive-builder.component.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Accordion, AccordionItem, Button, InlineLoading } from "@carbon/react";
-import { Add, Edit, TrashCan } from "@carbon/react/icons";
+import { Add, Edit, Replicate, TrashCan } from "@carbon/react/icons";
 import { useParams } from "react-router-dom";
 import { showToast, showNotification } from "@openmrs/esm-framework";
 import { OHRIFormSchema } from "@ohri/openmrs-ohri-form-engine-lib";
@@ -161,6 +161,34 @@ const InteractiveBuilder: React.FC<InteractiveBuilderProps> = ({
     } catch (error) {
       showNotification({
         title: t("errorRenamingSection", "Error renaming section"),
+        kind: "error",
+        critical: true,
+        description: error?.message,
+      });
+    }
+  };
+
+  const duplicateQuestion = (question) => {
+    try {
+      const questionToDuplicate = JSON.parse(JSON.stringify(question));
+      questionToDuplicate.id = questionToDuplicate.id + "Duplicate";
+
+      schema.pages[pageIndex].sections[sectionIndex].questions.push(
+        questionToDuplicate
+      );
+
+      onSchemaChange({ ...schema });
+      resetIndices();
+
+      showToast({
+        title: t("success", "Success!"),
+        kind: "success",
+        critical: true,
+        description: t("questionDuplicated", "Question duplicated"),
+      });
+    } catch (error) {
+      showNotification({
+        title: t("errorDuplicatingQuestion", "Error duplicating question"),
         kind: "error",
         critical: true,
         description: error?.message,
@@ -345,6 +373,7 @@ const InteractiveBuilder: React.FC<InteractiveBuilderProps> = ({
                 </div>
                 <Button
                   hasIconOnly
+                  enterDelayMs={200}
                   iconDescription={t("deletePage", "Delete page")}
                   kind="ghost"
                   onClick={() => {
@@ -387,6 +416,7 @@ const InteractiveBuilder: React.FC<InteractiveBuilderProps> = ({
                             </div>
                             <Button
                               hasIconOnly
+                              enterDelayMs={200}
                               iconDescription={t(
                                 "deleteSection",
                                 "Delete section"
@@ -417,28 +447,51 @@ const InteractiveBuilder: React.FC<InteractiveBuilderProps> = ({
                                       <p className={styles.questionLabel}>
                                         {question.label}
                                       </p>
-                                      <Button
-                                        kind="ghost"
-                                        size="sm"
-                                        iconDescription={t(
-                                          "editQuestion",
-                                          "Edit question"
-                                        )}
-                                        onClick={() => {
-                                          editQuestion();
-                                          setPageIndex(pageIndex);
-                                          setSectionIndex(sectionIndex);
-                                          setQuestionIndex(questionIndex);
-                                          setQuestionToEdit(question);
-                                        }}
-                                        renderIcon={(props) => (
-                                          <Edit size={16} {...props} />
-                                        )}
-                                        hasIconOnly
-                                      />
+                                      <div className={styles.buttonContainer}>
+                                        <Button
+                                          kind="ghost"
+                                          size="sm"
+                                          enterDelayMs={200}
+                                          iconDescription={t(
+                                            "duplicateQuestion",
+                                            "Duplicate question"
+                                          )}
+                                          onClick={() => {
+                                            duplicateQuestion(question);
+                                            setPageIndex(pageIndex);
+                                            setSectionIndex(sectionIndex);
+                                            setQuestionIndex(questionIndex);
+                                          }}
+                                          renderIcon={(props) => (
+                                            <Replicate size={16} {...props} />
+                                          )}
+                                          hasIconOnly
+                                        />
+                                        <Button
+                                          kind="ghost"
+                                          size="sm"
+                                          enterDelayMs={200}
+                                          iconDescription={t(
+                                            "editQuestion",
+                                            "Edit question"
+                                          )}
+                                          onClick={() => {
+                                            editQuestion();
+                                            setPageIndex(pageIndex);
+                                            setSectionIndex(sectionIndex);
+                                            setQuestionIndex(questionIndex);
+                                            setQuestionToEdit(question);
+                                          }}
+                                          renderIcon={(props) => (
+                                            <Edit size={16} {...props} />
+                                          )}
+                                          hasIconOnly
+                                        />
+                                      </div>
                                     </div>
                                     <Button
                                       hasIconOnly
+                                      enterDelayMs={200}
                                       iconDescription={t(
                                         "deleteQuestion",
                                         "Delete question"

--- a/src/components/interactive-builder/interactive-builder.scss
+++ b/src/components/interactive-builder/interactive-builder.scss
@@ -85,6 +85,12 @@
   width: 100%;
 }
 
+.buttonContainer {
+  span {
+    margin: 0rem 0.5rem;
+  }
+}
+
 .questionLabel {
   @include type.type-style('body-01');
 }


### PR DESCRIPTION
## Summary

This PR adds the ability to duplicate questions using the interactive builder. The duplicated question gets a placeholder question ID which ought to be changed by the user. This is meant to help the user scaffold out a form quickly.

Additionally, this PR also ups the `enterDelayMs` property value of several icon buttons to 200ms, ensuring that icon tooltips don't overlap. 

## Video

https://user-images.githubusercontent.com/8509731/211738657-07bf851d-ea88-43fb-bd4b-4215f0e65fb3.mp4

