### PR TITLE
(chore) Fix release command in CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -108,7 +108,7 @@ jobs:
           node-version: "16.x"
           registry-url: 'https://registry.npmjs.org'
       - run: yarn
-      - run: yarn publish --access public --tag latest
+      - run: yarn npm publish --access public --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 


### PR DESCRIPTION
Fixes the release command used in the `release` job of our primary CI workflow (which is currently failing [here](https://github.com/openmrs/openmrs-esm-form-builder/actions/runs/3905768430/jobs/6673178440)).