### PR TITLE
O3-1792: Fix issues with retrieving form resource where there exists both html and JSON form resource

### DIFF
--- a/src/hooks/useClobdata.ts
+++ b/src/hooks/useClobdata.ts
@@ -3,9 +3,11 @@ import { openmrsFetch } from "@openmrs/esm-framework";
 import { Form, Schema } from "../types";
 
 export const useClobdata = (form?: Form) => {
-  const valueReference = form?.resources?.[0].valueReference;
-  const formHasResources = form?.resources.length > 0 && valueReference;
-  const CLOBDATA_URL = `/ws/rest/v1/clobdata/${valueReference}`;
+  const valueReferenceUuid = form?.resources?.find(
+    ({ name }) => name === "JSON schema"
+  )?.valueReference;
+  const formHasResources = form?.resources.length > 0 && valueReferenceUuid;
+  const CLOBDATA_URL = `/ws/rest/v1/clobdata/${valueReferenceUuid}`;
 
   const { data, error } = useSWRImmutable<{ data: Schema }, Error>(
     formHasResources ? CLOBDATA_URL : null,


### PR DESCRIPTION
### What does this PR do.

1. Fix error while trying to retrieve form resource where we have both `JSON` and `HTML` form resource. For scenarios where users don't what to create new forms but use existing `formUuid` and add the JSON resource to enable use of htmlforms 

### Screenshoot 
![image](https://user-images.githubusercontent.com/28008754/213534302-983ad92c-e719-4722-b6bb-cd8d4c447dc3.png)

As seen above the form has both `hfexmlPath` and `AmpthJsonSchema` resources for `Alcohol  Abuse Screening form`
