### PR TITLE
(fix) Append `multipart/form-data` content type to request headers

### DIFF
--- a/src/forms.resource.ts
+++ b/src/forms.resource.ts
@@ -34,7 +34,7 @@ export const uploadSchema = async (schema: Schema) => {
   body.append("file", schemaBlob);
   const headers = {
     Accept: "application/json",
-    "Content-Type": undefined,
+    "Content-Type": "multipart/form-data",
   };
 
   const request = await openmrsFetch(`/ws/rest/v1/clobdata`, {


### PR DESCRIPTION
Potentially fixes a bug where form schemas would fail to upload schema blobs to the `clobdata` endpoint. 