### PR TITLE
(fix) Fixes a flaw in the duplicate question feature

### DIFF
--- a/src/components/interactive-builder/interactive-builder.component.tsx
+++ b/src/components/interactive-builder/interactive-builder.component.tsx
@@ -184,7 +184,10 @@ const InteractiveBuilder: React.FC<InteractiveBuilderProps> = ({
         title: t("success", "Success!"),
         kind: "success",
         critical: true,
-        description: t("questionDuplicated", "Question duplicated"),
+        description: t(
+          "questionDuplicated",
+          "Question duplicated. Please change the duplicated question's ID to a unique, camelcased value"
+        ),
       });
     } catch (error) {
       showNotification({

--- a/src/components/interactive-builder/interactive-builder.component.tsx
+++ b/src/components/interactive-builder/interactive-builder.component.tsx
@@ -168,12 +168,12 @@ const InteractiveBuilder: React.FC<InteractiveBuilderProps> = ({
     }
   };
 
-  const duplicateQuestion = (question) => {
+  const duplicateQuestion = (question, pageId, sectionId) => {
     try {
       const questionToDuplicate = JSON.parse(JSON.stringify(question));
       questionToDuplicate.id = questionToDuplicate.id + "Duplicate";
 
-      schema.pages[pageIndex].sections[sectionIndex].questions.push(
+      schema.pages[pageId].sections[sectionId].questions.push(
         questionToDuplicate
       );
 
@@ -463,12 +463,13 @@ const InteractiveBuilder: React.FC<InteractiveBuilderProps> = ({
                                             "duplicateQuestion",
                                             "Duplicate question"
                                           )}
-                                          onClick={() => {
-                                            duplicateQuestion(question);
-                                            setPageIndex(pageIndex);
-                                            setSectionIndex(sectionIndex);
-                                            setQuestionIndex(questionIndex);
-                                          }}
+                                          onClick={() =>
+                                            duplicateQuestion(
+                                              question,
+                                              pageIndex,
+                                              sectionIndex
+                                            )
+                                          }
                                           renderIcon={(props) => (
                                             <Replicate size={16} {...props} />
                                           )}


### PR DESCRIPTION
Fixes https://github.com/openmrs/openmrs-esm-form-builder/issues/72 where a flaw in the duplicate question feature caused questions from one section to be duplicated in a completely different section. 

## Video

https://user-images.githubusercontent.com/8509731/230215018-63bc3c0f-b660-4b34-8dc2-ff4bd1e727ec.mp4



> Updated toast with a reminder to change the duplicated question's ID.

<img width="366" alt="Screenshot 2023-04-06 at 12 24 42 AM" src="https://user-images.githubusercontent.com/8509731/230215048-ff39a683-a754-4b1f-b620-8ddbb1f3bc7d.png">

