### PR TITLE
(fix) Update test patient UUID

### DIFF
--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -40,7 +40,7 @@ export const configSchema = {
   },
   patientUuid: {
     _type: "String",
-    _default: "6e0c17ae-da79-4d48-93d9-396ff82b98d4",
+    _default: "b418d852-0a0e-437e-a79c-472588612269",
     _description:
       "UUID of the test patient whose information gets rendered in a patient banner within the form renderer",
   },


### PR DESCRIPTION
Fixes an issue where the configured test patient UUID used to load patient details in the banner doesn't match a UUID of an existing test patient. This causes the form preview to fail to load. Ideally, we should have a more robust way for handling this, but that should be done in the form engine, not here.

<img width="1170" alt="Screenshot 2023-04-10 at 9 49 54 PM" src="https://user-images.githubusercontent.com/8509731/230971992-fb8f5998-3bad-464a-a237-afa2d95aa6ba.png">
