### PR TITLE
(chore) Bump react-error-boundary

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "pretty-quick": "^3.1.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-error-boundary": "^3.1.4",
+    "react-error-boundary": "^4.0.4",
     "react-i18next": "^11.18.6",
     "rxjs": "^7.8.0",
     "swc-loader": "^0.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2792,7 +2792,7 @@ __metadata:
     react: ^18.2.0
     react-ace: ^10.1.0
     react-dom: ^18.2.0
-    react-error-boundary: ^3.1.4
+    react-error-boundary: ^4.0.4
     react-i18next: ^11.18.6
     rxjs: ^7.8.0
     sass: ^1.58.0
@@ -14238,7 +14238,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-error-boundary@npm:3.1.4, react-error-boundary@npm:^3.1.4":
+"react-error-boundary@npm:3.1.4":
   version: 3.1.4
   resolution: "react-error-boundary@npm:3.1.4"
   dependencies:
@@ -14246,6 +14246,17 @@ __metadata:
   peerDependencies:
     react: ">=16.13.1"
   checksum: f36270a5d775a25c8920f854c0d91649ceea417b15b5bc51e270a959b0476647bb79abb4da3be7dd9a4597b029214e8fe43ea914a7f16fa7543c91f784977f1b
+  languageName: node
+  linkType: hard
+
+"react-error-boundary@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "react-error-boundary@npm:4.0.4"
+  dependencies:
+    "@babel/runtime": ^7.12.5
+  peerDependencies:
+    react: ">=16.13.1"
+  checksum: 02f04bdf8526f4b2474cb129ece32e5e32fbe81a72a71fdcf056c440aa9f4308b372383f5e817eea76220dcf0901459be2834d6ab8106cd9c36e8ec230df70f9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps `react-error-boundary` to a version commensurate with what the [form engine](https://github.com/openmrs/openmrs-form-engine-lib) uses. Presently, the version mismatch is causing attempts to link the library to fail silently, which hampers local development.