### PR TITLE
(feat) Prevent modals from closing when clicking outside

### DIFF
--- a/src/components/action-buttons/action-buttons.component.tsx
+++ b/src/components/action-buttons/action-buttons.component.tsx
@@ -140,6 +140,7 @@ function ActionButtons({ schema, t }) {
           <ComposedModal
             open={true}
             onClose={() => setShowUnpublishModal(false)}
+            preventCloseOnClickOutside
           >
             <ModalHeader
               title={t(

--- a/src/components/interactive-builder/add-question-modal.component.tsx
+++ b/src/components/interactive-builder/add-question-modal.component.tsx
@@ -178,7 +178,11 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
   };
 
   return (
-    <ComposedModal open={showModal} onClose={() => onModalChange(false)}>
+    <ComposedModal
+      open={showModal}
+      onClose={() => onModalChange(false)}
+      preventCloseOnClickOutside
+    >
       <ModalHeader title={t("createNewQuestion", "Create a new question")} />
       <Form
         className={styles.form}

--- a/src/components/interactive-builder/delete-page-modal.component.tsx
+++ b/src/components/interactive-builder/delete-page-modal.component.tsx
@@ -53,7 +53,11 @@ const DeletePageModal: React.FC<DeletePageModalProps> = ({
   };
 
   return (
-    <ComposedModal open={showModal} onClose={() => onModalChange(false)}>
+    <ComposedModal
+      open={showModal}
+      onClose={() => onModalChange(false)}
+      preventCloseOnClickOutside
+    >
       <ModalHeader
         title={t(
           "deletePageConfirmation",

--- a/src/components/interactive-builder/delete-question-modal.component.tsx
+++ b/src/components/interactive-builder/delete-question-modal.component.tsx
@@ -60,7 +60,11 @@ const DeleteQuestionModal: React.FC<DeleteQuestionModal> = ({
   };
 
   return (
-    <ComposedModal open={showModal} onClose={() => onModalChange(false)}>
+    <ComposedModal
+      open={showModal}
+      onClose={() => onModalChange(false)}
+      preventCloseOnClickOutside
+    >
       <ModalHeader
         title={t(
           "deleteQuestionConfirmation",

--- a/src/components/interactive-builder/delete-section-modal.component.tsx
+++ b/src/components/interactive-builder/delete-section-modal.component.tsx
@@ -55,7 +55,11 @@ const DeleteSectionModal: React.FC<DeleteSectionModal> = ({
   };
 
   return (
-    <ComposedModal open={showModal} onClose={() => onModalChange(false)}>
+    <ComposedModal
+      open={showModal}
+      onClose={() => onModalChange(false)}
+      preventCloseOnClickOutside
+    >
       <ModalHeader
         title={t(
           "deleteSectionConfirmation",

--- a/src/components/interactive-builder/edit-question-modal.component.tsx
+++ b/src/components/interactive-builder/edit-question-modal.component.tsx
@@ -196,7 +196,11 @@ const EditQuestionModal: React.FC<EditQuestionModalProps> = ({
   };
 
   return (
-    <ComposedModal open={showModal} onClose={() => onModalChange(false)}>
+    <ComposedModal
+      open={showModal}
+      onClose={() => onModalChange(false)}
+      preventCloseOnClickOutside
+    >
       <ModalHeader title={t("editQuestion", "Edit question")} />
       <Form
         className={styles.form}

--- a/src/components/interactive-builder/new-form-modal.component.tsx
+++ b/src/components/interactive-builder/new-form-modal.component.tsx
@@ -51,7 +51,11 @@ const NewFormModal: React.FC<NewFormModalProps> = ({
   };
 
   return (
-    <ComposedModal open={showModal} onClose={() => onModalChange(false)}>
+    <ComposedModal
+      open={showModal}
+      onClose={() => onModalChange(false)}
+      preventCloseOnClickOutside
+    >
       <ModalHeader title={t("createNewForm", "Create a new form")} />
       <Form onSubmit={(event) => event.preventDefault()}>
         <ModalBody>

--- a/src/components/interactive-builder/page-modal.component.tsx
+++ b/src/components/interactive-builder/page-modal.component.tsx
@@ -62,7 +62,11 @@ const PageModal: React.FC<PageModalProps> = ({
   };
 
   return (
-    <ComposedModal open={showModal} onClose={() => onModalChange(false)}>
+    <ComposedModal
+      open={showModal}
+      onClose={() => onModalChange(false)}
+      preventCloseOnClickOutside
+    >
       <ModalHeader title={t("createNewPage", "Create a new page")} />
       <Form onSubmit={(event) => event.preventDefault()}>
         <ModalBody>

--- a/src/components/interactive-builder/section-modal.component.tsx
+++ b/src/components/interactive-builder/section-modal.component.tsx
@@ -66,7 +66,11 @@ const SectionModal: React.FC<SectionModalProps> = ({
   };
 
   return (
-    <ComposedModal open={showModal} onClose={() => onModalChange(false)}>
+    <ComposedModal
+      open={showModal}
+      onClose={() => onModalChange(false)}
+      preventCloseOnClickOutside
+    >
       <ModalHeader title={t("createNewSection", "Create a new section")} />
       <Form onSubmit={(event) => event.preventDefault()}>
         <ModalBody>

--- a/src/components/modals/save-form.component.tsx
+++ b/src/components/modals/save-form.component.tsx
@@ -218,6 +218,7 @@ const SaveForm: React.FC<SaveFormModalProps> = ({ form, schema, onMutate }) => {
         <ComposedModal
           open={openConfirmSaveModal}
           onClose={() => setOpenConfirmSaveModal(false)}
+          preventCloseOnClickOutside
         >
           <ModalHeader title={t("saveConfirmation", "Save or Update form")} />
           <ModalBody>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Prevents modals from closing when the user clicks outside the modal container.

## Video

https://user-images.githubusercontent.com/8509731/233502122-37b80dc4-d0ac-44ab-9abb-862addb01de6.mp4
