### PR TITLE
(fix) ensure users do not input wrong version numbers

### DIFF
--- a/src/components/modals/save-form.component.tsx
+++ b/src/components/modals/save-form.component.tsx
@@ -57,12 +57,12 @@ const SaveForm: React.FC<SaveFormModalProps> = ({ form, schema, onMutate }) => {
   const [openConfirmSaveModal, setOpenConfirmSaveModal] = useState(false);
   const [saveState, setSaveState] = useState("");
   const [isSavingForm, setIsSavingForm] = useState(false);
-  const [hasValidVersion, setHasValidVersion] = useState(false);
+  const [isInvalidVersion, setIsInvalidVersion] = useState(false);
 
-  const isVersionValid = (version: string) => {
-    if (version === "") return setHasValidVersion(false);
-    const versionRegex = new RegExp(/^[0-9]/);
-    setHasValidVersion(Boolean(!versionRegex.test(version)));
+  const checkVersionValidity = (version: string) => {
+    if (!version) return setIsInvalidVersion(false);
+
+    setIsInvalidVersion(!/^[0-9]/.test(version));
   };
 
   const openModal = useCallback((option) => {
@@ -295,11 +295,11 @@ const SaveForm: React.FC<SaveFormModalProps> = ({ form, schema, onMutate }) => {
                   defaultValue={saveState === "update" ? form?.version : ""}
                   placeholder="e.g. 1.0"
                   required
-                  onChange={(event) => isVersionValid(event.target.value)}
-                  invalid={hasValidVersion}
+                  onChange={(event) => checkVersionValidity(event.target.value)}
+                  invalid={isInvalidVersion}
                   invalidText={t(
-                    "versionErrorMessages",
-                    "Version cannot start with letters ensure valid version e.g 1.0"
+                    "invalidVersionWarning",
+                    "Version can only start with with a number"
                   )}
                 />
                 <Select
@@ -351,7 +351,7 @@ const SaveForm: React.FC<SaveFormModalProps> = ({ form, schema, onMutate }) => {
               {t("close", "Close")}
             </Button>
             <Button
-              disabled={isSavingForm || hasValidVersion}
+              disabled={isSavingForm || isInvalidVersion}
               className={styles.spinner}
               type={"submit"}
               kind={"primary"}

--- a/src/components/modals/save-form.component.tsx
+++ b/src/components/modals/save-form.component.tsx
@@ -57,6 +57,13 @@ const SaveForm: React.FC<SaveFormModalProps> = ({ form, schema, onMutate }) => {
   const [openConfirmSaveModal, setOpenConfirmSaveModal] = useState(false);
   const [saveState, setSaveState] = useState("");
   const [isSavingForm, setIsSavingForm] = useState(false);
+  const [hasValidVersion, setHasValidVersion] = useState(false);
+
+  const isVersionValid = (version: string) => {
+    if (version === "") return setHasValidVersion(false);
+    const versionRegex = new RegExp(/^[0-9]/);
+    setHasValidVersion(Boolean(!versionRegex.test(version)));
+  };
 
   const openModal = useCallback((option) => {
     if (option === "newVersion") {
@@ -250,6 +257,7 @@ const SaveForm: React.FC<SaveFormModalProps> = ({ form, schema, onMutate }) => {
       ) : null}
 
       <ComposedModal
+        preventCloseOnClickOutside
         open={openSaveFormModal}
         onClose={() => setOpenSaveFormModal(false)}
       >
@@ -287,6 +295,12 @@ const SaveForm: React.FC<SaveFormModalProps> = ({ form, schema, onMutate }) => {
                   defaultValue={saveState === "update" ? form?.version : ""}
                   placeholder="e.g. 1.0"
                   required
+                  onChange={(event) => isVersionValid(event.target.value)}
+                  invalid={hasValidVersion}
+                  invalidText={t(
+                    "versionErrorMessages",
+                    "Version cannot start with letters ensure valid version e.g 1.0"
+                  )}
                 />
                 <Select
                   id="encounterType"
@@ -337,7 +351,7 @@ const SaveForm: React.FC<SaveFormModalProps> = ({ form, schema, onMutate }) => {
               {t("close", "Close")}
             </Button>
             <Button
-              disabled={isSavingForm}
+              disabled={isSavingForm || hasValidVersion}
               className={styles.spinner}
               type={"submit"}
               kind={"primary"}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
- Add check to ensure valid form version are saved

## Screenshots
![version](https://user-images.githubusercontent.com/28008754/233985726-d44e8fd3-5928-4485-a440-90512e5db081.gif)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
