### PR TITLE
(refactor) Use bound mutate API for revalidation

### DIFF
--- a/src/components/action-buttons/action-buttons.component.tsx
+++ b/src/components/action-buttons/action-buttons.component.tsx
@@ -8,7 +8,6 @@ import {
   ModalHeader,
 } from "@carbon/react";
 import { useParams } from "react-router-dom";
-import { useSWRConfig } from "swr";
 import { showToast, showNotification } from "@openmrs/esm-framework";
 
 import { RouteParams } from "../../types";
@@ -26,23 +25,13 @@ type Status =
   | "error";
 
 function ActionButtons({ schema, t }) {
-  const { cache, mutate }: { cache: any; mutate: Function } = useSWRConfig();
   const { formUuid } = useParams<RouteParams>();
-  const { form } = useForm(formUuid);
+  const { form, mutate } = useForm(formUuid);
   const [status, setStatus] = useState<Status>("idle");
   const [showUnpublishModal, setShowUnpublishModal] = useState(false);
 
   const launchUnpublishModal = () => {
     setShowUnpublishModal(true);
-  };
-
-  const revalidate = () => {
-    const apiUrlPattern = new RegExp("\\/ws\\/rest\\/v1\\/form");
-
-    // Find matching keys from SWR's cache and broadcast a revalidation message to their pre-bound SWR hooks
-    Array.from(cache.keys())
-      .filter((url: string) => apiUrlPattern.test(url))
-      .forEach((url: string) => mutate(url));
   };
 
   async function handlePublish() {
@@ -60,7 +49,7 @@ function ActionButtons({ schema, t }) {
       });
 
       setStatus("published");
-      revalidate();
+      mutate();
     } catch (error) {
       showNotification({
         title: t("errorPublishingForm", "Error publishing form"),
@@ -87,7 +76,7 @@ function ActionButtons({ schema, t }) {
       });
 
       setStatus("unpublished");
-      revalidate();
+      mutate();
     } catch (error) {
       showNotification({
         title: t("errorUnpublishingForm", "Error unpublishing form"),


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary

Removes the existing revalidation implementation in the `ActionButtons` component which relies on the [global mutate API](https://swr.vercel.app/docs/mutation#global-mutate) and replaces it with a call to a bound mutate function. Revalidation continues to work just as before, and the new implementation is cleaner and easier to maintain and understand.
