### PR TITLE
(feat) Change answers in edit mode when the linked concept changes

### DIFF
--- a/src/components/interactive-builder/add-question-modal.component.tsx
+++ b/src/components/interactive-builder/add-question-modal.component.tsx
@@ -193,6 +193,29 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
                 onChange={(event) => setQuestionLabel(event.target.value)}
                 required
               />
+
+              <TextInput
+                id="questionId"
+                invalid={questionIdExists(questionId)}
+                invalidText={t(
+                  "questionIdExists",
+                  "This question ID already exists in your schema"
+                )}
+                labelText={t(
+                  "questionId",
+                  "Question ID (prefer using camel-case for IDs)"
+                )}
+                value={questionId}
+                onChange={(event) => {
+                  setQuestionId(event.target.value);
+                }}
+                placeholder={t(
+                  "questionIdPlaceholder",
+                  'Enter a unique ID e.g. "anaesthesiaType" for a question asking about the type of anaesthesia.'
+                )}
+                required
+              />
+
               <RadioButtonGroup
                 defaultSelected="optional"
                 name="isQuestionRequired"
@@ -216,6 +239,7 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
                   value="required"
                 />
               </RadioButtonGroup>
+
               <Select
                 value={questionType}
                 onChange={(event) => setQuestionType(event.target.value)}
@@ -238,6 +262,7 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
                   />
                 ))}
               </Select>
+
               <Select
                 value={fieldType}
                 onChange={(event) => setFieldType(event.target.value)}
@@ -259,6 +284,7 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
                   <SelectItem text={fieldType} value={fieldType} key={key} />
                 ))}
               </Select>
+
               {fieldType === "number" ? (
                 <>
                   <TextInput
@@ -377,7 +403,10 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
               )}
 
               {conceptMappings && conceptMappings.length ? (
-                <>
+                <FormGroup>
+                  <FormLabel className={styles.label}>
+                    {t("mappings", "Mappings")}
+                  </FormLabel>
                   <table className={styles.tableStriped}>
                     <thead>
                       <tr>
@@ -396,7 +425,7 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
                       ))}
                     </tbody>
                   </table>
-                </>
+                </FormGroup>
               ) : null}
 
               {answers && answers.length ? (
@@ -428,28 +457,6 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
                   ))}
                 </div>
               ) : null}
-
-              <TextInput
-                id="questionId"
-                invalid={questionIdExists(questionId)}
-                invalidText={t(
-                  "questionIdExists",
-                  "This question ID already exists in your schema"
-                )}
-                labelText={t(
-                  "questionId",
-                  "Question ID (prefer camel-case for IDs)"
-                )}
-                value={questionId}
-                onChange={(event) => {
-                  setQuestionId(event.target.value);
-                }}
-                placeholder={t(
-                  "questionIdPlaceholder",
-                  'Enter a unique ID e.g. "anaesthesiaType" for a question asking about the type of anaesthesia.'
-                )}
-                required
-              />
             </Stack>
           </FormGroup>
         </ModalBody>

--- a/src/components/interactive-builder/interactive-builder.component.tsx
+++ b/src/components/interactive-builder/interactive-builder.component.tsx
@@ -6,7 +6,7 @@ import { useParams } from "react-router-dom";
 import { showToast, showNotification } from "@openmrs/esm-framework";
 import { OHRIFormSchema } from "@openmrs/openmrs-form-engine-lib";
 
-import type { Question, RouteParams, Schema } from "../../types";
+import type { RouteParams, Schema } from "../../types";
 import ActionButtons from "../action-buttons/action-buttons.component";
 import AddQuestionModal from "./add-question-modal.component";
 import DeleteSectionModal from "./delete-section-modal.component";
@@ -171,7 +171,7 @@ const InteractiveBuilder: React.FC<InteractiveBuilderProps> = ({
   );
 
   const duplicateQuestion = useCallback(
-    (question: Question, pageId: number, sectionId: number) => {
+    (question, pageId: number, sectionId: number) => {
       try {
         const questionToDuplicate = JSON.parse(JSON.stringify(question));
         questionToDuplicate.id = questionToDuplicate.id + "Duplicate";

--- a/src/components/interactive-builder/question-modal.scss
+++ b/src/components/interactive-builder/question-modal.scss
@@ -6,7 +6,7 @@
 }
 
 .loader {
-  padding: 1rem 0.5rem;
+  padding: 0.75rem 0.5rem;
 }
 
 .tag {

--- a/src/components/interactive-builder/question-modal.scss
+++ b/src/components/interactive-builder/question-modal.scss
@@ -18,6 +18,7 @@
 }
 
 .conceptList {
+  background: white;
   max-height: 14rem;
   overflow-y: auto;
   border: 1px solid $ui-03;
@@ -30,6 +31,11 @@
 
 .concept {
   padding: 0.75rem;
+  border-bottom: 1px solid $ui-03;
+
+  &:last-of-type {
+    border-bottom: none;
+  }
 }
 
 .emptyResults {

--- a/translations/en.json
+++ b/translations/en.json
@@ -90,7 +90,7 @@
   "publishing": "Publishing",
   "questionCreated": "New question created",
   "QuestionDeleted": "Question deleted",
-  "questionId": "Question ID (prefer camel-case for IDs)",
+  "questionId": "Question ID (prefer using camel-case for IDs)",
   "questionIdExists": "This question ID already exists in your schema",
   "questionIdPlaceholder": "Enter a unique ID e.g. \"anaesthesiaType\" for a question asking about the type of anaesthesia.",
   "questionLabel": "Label",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
 
This PR tweaks the `Edit question` form so that when the concept changes following a search, the answers dropdown gets updated to show the new concept's choices. Additionally, concept lookup gets debounced so the request only occurs after a 500 ms delay.

## Video

https://github.com/openmrs/openmrs-esm-form-builder/assets/8509731/3f3e0936-8182-4c1d-96ef-05b780b8a24c