### PR TITLE
(fix) O3-2094: Save the encounter type when the form is saved

### DIFF
--- a/src/components/modals/save-form.component.tsx
+++ b/src/components/modals/save-form.component.tsx
@@ -100,7 +100,16 @@ const SaveForm: React.FC<SaveFormModalProps> = ({ form, schema }) => {
           description,
           encounterType
         );
-        const newValueReference = await uploadSchema(schema);
+
+        const updatedSchema = {
+          ...schema,
+          name: name,
+          version: version,
+          description: description,
+          encounterType: encounterType,
+        };
+
+        const newValueReference = await uploadSchema(updatedSchema);
         await getResourceUuid(newForm.uuid, newValueReference.toString());
         showToast({
           title: t("formCreated", "New form created"),

--- a/src/components/modals/save-form.component.tsx
+++ b/src/components/modals/save-form.component.tsx
@@ -92,25 +92,13 @@ const SaveForm: React.FC<SaveFormModalProps> = ({ form, schema }) => {
         encounterType = event.target.encounterType.value,
         description = event.target.description.value;
 
-      let encounterTypeUUID = "";
-
-      if (encounterType === "undefined") {
-        encounterTypeUUID = undefined;
-      } else {
-        encounterTypes.forEach((encType) => {
-          if (encounterType === encType.name) {
-            encounterTypeUUID = encType.uuid;
-          }
-        });
-      }
-
       try {
         const newForm = await saveNewForm(
           name,
           version,
           false,
           description,
-          encounterTypeUUID
+          encounterType
         );
         const newValueReference = await uploadSchema(schema);
         await getResourceUuid(newForm.uuid, newValueReference.toString());


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR fixes the issue with not saving the encounter type. The issue was a misunderstanding about the encounter input value. It was the UUID but the code was written thinking it was the encounter name. Therefore the unnecessary part was removed from the code.

## Screenshots
<!-- Required if you are making UI changes. -->
<img width="546" alt="image" src="https://github.com/openmrs/openmrs-esm-form-builder/assets/43912578/c1fcaa08-e6de-419e-8623-c4e45876e46c">
<img width="554" alt="image" src="https://github.com/openmrs/openmrs-esm-form-builder/assets/43912578/1e7d7c08-eabf-415d-98e0-92c3a49568d1">


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://issues.openmrs.org/browse/O3-2094

## Other
<!-- Anything not covered above -->
None