### PR TITLE
(fix) O3-2124: Unable to save a form after initial save

### DIFF
--- a/src/components/form-editor/form-editor.component.tsx
+++ b/src/components/form-editor/form-editor.component.tsx
@@ -54,13 +54,22 @@ const FormEditor: React.FC = () => {
     formUuid && (isLoadingClobdata || isLoadingForm);
 
   useEffect(() => {
-    if (formUuid && clobdata && Object.keys(clobdata).length > 0) {
-      setSchema(clobdata);
-      localStorage.setItem("formJSON", JSON.stringify(clobdata));
-    } else if (formUuid && !isLoadingFormOrSchema && !schema) {
-      setShowLoadDraftSchemaModal(true);
+    if (formUuid) {
+      if (
+        !isLoadingFormOrSchema &&
+        clobdata &&
+        Object.keys(clobdata).length > 0
+      ) {
+        setSchema(clobdata);
+        localStorage.setItem("formJSON", JSON.stringify(clobdata));
+      } else if (
+        !isLoadingFormOrSchema &&
+        (!clobdata || Object.keys(clobdata).length === 0)
+      ) {
+        setShowLoadDraftSchemaModal(true);
+      }
     }
-  }, [clobdata, formUuid, isLoadingFormOrSchema, schema]);
+  }, [clobdata, formUuid, isLoadingFormOrSchema]);
 
   const updateSchema = useCallback((updatedSchema) => {
     setSchema(updatedSchema);

--- a/src/components/modals/save-form.component.tsx
+++ b/src/components/modals/save-form.component.tsx
@@ -85,7 +85,9 @@ const SaveForm: React.FC<SaveFormModalProps> = ({ form, schema }) => {
     }
   }, []);
 
-  const handleSubmit = async (event: SyntheticEvent) => {
+  const handleSubmit = async (
+    event: SyntheticEvent<{ name: { value: string } }>
+  ) => {
     event.preventDefault();
     setIsSavingForm(true);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,7 @@ export interface Schema {
   uuid: string;
   encounterType: string;
   referencedForms: [];
+  version?: string;
 }
 
 export interface SchemaContextType {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR fixes an issue where edits made to a form schema via the schema editor would disappear after the `render changes` button gets clicked. This was likely due to the changes to the `useEffect` login in the `FormEditor` component introduced in https://github.com/openmrs/openmrs-esm-form-builder/pull/107/files.

This PR also fixes how the Save Modal obtains its values from the form and schema objects. Following these changes, the form save workflow should now more reliably pick the `name`, `version`, `uuid`, `encounterType`,  and `description` properties of a form from the provided props. 

It also adds a call to  `mutate()` which gets invoked after saving a new form so that the form gets revalidated immediately. The benefit of this is that the schema editor can pick up any changes to the form so that when we edit it again, we have access to the most up-to-date version of the form.


## Related issue

https://issues.openmrs.org/browse/O3-2124
