### PR TITLE
(tests) Add E2E tests for searching and filtering the form list.

### DIFF
--- a/e2e/pages/formBuilderPage.ts
+++ b/e2e/pages/formBuilderPage.ts
@@ -82,8 +82,8 @@ export class FormBuilderPage {
       name: /filter by publish status/i,
     });
 
-  readonly publishedOption = () =>
-    this.page.getByRole("option", { name: "Published", exact: true });
+  readonly unPublishedOption = () =>
+    this.page.getByRole("option", { name: "Unpublished", exact: true });
 
   readonly searchbox = () => this.page.getByRole("searchbox");
 

--- a/e2e/pages/formBuilderPage.ts
+++ b/e2e/pages/formBuilderPage.ts
@@ -77,16 +77,6 @@ export class FormBuilderPage {
   readonly publishFormButton = () =>
     this.page.getByRole("button", { name: "Publish Form" });
 
-  readonly publishStatusDropdownButton = () =>
-    this.page.getByRole("button", {
-      name: /filter by publish status/i,
-    });
-
-  readonly unPublishedOption = () =>
-    this.page.getByRole("option", { name: "Unpublished", exact: true });
-
-  readonly searchbox = () => this.page.getByRole("searchbox");
-
   async gotoFormBuilder() {
     await this.page.goto("form-builder");
   }

--- a/e2e/pages/formBuilderPage.ts
+++ b/e2e/pages/formBuilderPage.ts
@@ -74,6 +74,20 @@ export class FormBuilderPage {
     this.page.getByText(/new question created/i);
   readonly saveQuestionButton = () =>
     this.page.getByRole("button", { name: /^save$/i, exact: true });
+  readonly publishFormButton = () =>
+    this.page.getByRole("button", { name: "Publish Form" });
+
+  readonly publishStatusDropdownButton = () =>
+    this.page.getByRole("button", {
+      name: /filter by publish status/i,
+    });
+
+  readonly publishedOption = () =>
+    this.page.getByRole("option", { name: "Published", exact: true });
+
+  readonly searchbox = () => this.page.getByRole("searchbox");
+  readonly tableContainer = () =>
+    this.page.locator(".cds--data-table-container");
 
   async gotoFormBuilder() {
     await this.page.goto("form-builder");

--- a/e2e/pages/formBuilderPage.ts
+++ b/e2e/pages/formBuilderPage.ts
@@ -86,8 +86,6 @@ export class FormBuilderPage {
     this.page.getByRole("option", { name: "Published", exact: true });
 
   readonly searchbox = () => this.page.getByRole("searchbox");
-  readonly tableContainer = () =>
-    this.page.locator(".cds--data-table-container");
 
   async gotoFormBuilder() {
     await this.page.goto("form-builder");

--- a/e2e/specs/formsDashboard.spec.ts
+++ b/e2e/specs/formsDashboard.spec.ts
@@ -1,0 +1,105 @@
+import { test } from "../core";
+import { expect } from "@playwright/test";
+import { FormBuilderPage } from "../pages";
+import { deleteForm } from "../commands/formOperations";
+
+let formUuid = null;
+
+test("should filter forms based on publish status", async ({ page }) => {
+  const formBuilderPage = new FormBuilderPage(page);
+  await formBuilderPage.gotoFormBuilder();
+
+  await formBuilderPage.createNewFormButton().click();
+
+  // Inputs the dummy schema
+  await formBuilderPage.inputDummySchemaButton().click();
+  // await formBuilderPage.renderChangesButton().click();
+
+  // Save the form
+  await formBuilderPage.saveForm();
+  await formBuilderPage.publishFormButton().click();
+  await formBuilderPage.gotoFormBuilder();
+
+  // Select the "Published" filter option
+  await formBuilderPage.publishStatusDropdownButton().click();
+
+  await formBuilderPage.publishedOption().click();
+
+  // Wait for the table to update with filtered results
+  await formBuilderPage.tableContainer();
+
+  // Assert that only published forms are displayed in the table
+  const tableRows = await page.$$eval(
+    ".cds--data-table tbody tr",
+    (rows) => rows
+  );
+
+  expect(tableRows.length).toBeGreaterThan(1);
+
+  const tableRow = await page.$(".cds--data-table tbody tr");
+  const thirdTdElement = await tableRow.evaluateHandle((row) =>
+    row.querySelector("td:nth-child(3)")
+  );
+
+  // Locate the <div> element with the publish status tag
+  const publishStatusTag = await thirdTdElement.$(".cds--tag");
+
+  // Get the text content of the publish status tag
+  const publishStatusText = await publishStatusTag.$eval(
+    "span",
+    (spanElement) => spanElement.textContent
+  );
+
+  // Expect the publish status to be "Yes"
+  expect(publishStatusText).toBe("Yes");
+});
+
+test("should search forms by name", async ({ page }) => {
+  const formBuilderPage = new FormBuilderPage(page);
+  await formBuilderPage.gotoFormBuilder();
+
+  await formBuilderPage.createNewFormButton().click();
+
+  // Inputs the custom schema
+  await formBuilderPage.inputDummySchemaButton().click();
+
+  // Save the form
+  await formBuilderPage.saveForm();
+  await formBuilderPage.publishFormButton().click();
+
+  const editFormPageURLRegex = new RegExp("/edit/");
+  await page.waitForURL(editFormPageURLRegex);
+  const editFormPageURL = await page.url();
+  formUuid = editFormPageURL.split("/").slice(-1)[0];
+
+  await formBuilderPage.gotoFormBuilder();
+
+  await formBuilderPage.searchbox().type("Sample Form");
+
+  await formBuilderPage.tableContainer();
+
+  // Assert that only published forms are displayed in the table
+  const tableRows = await page.$$eval(
+    ".cds--data-table tbody tr",
+    (rows) => rows
+  );
+
+  expect(tableRows.length).toBeGreaterThan(1);
+  const searchBoxValue = await formBuilderPage
+    .searchbox()
+    .getAttribute("value");
+  expect(searchBoxValue).toBe("Sample Form");
+
+  const tableRow = await page.$(".cds--data-table tbody tr");
+  const tdElement = await tableRow.$("td");
+  const tdNameTextContent = await tdElement.textContent();
+
+  // Expect the form name to be "test form"
+  expect(tdNameTextContent).toBe("Sample Form");
+});
+
+test.afterEach(async ({ api }) => {
+  if (formUuid) {
+    await deleteForm(api, formUuid);
+  }
+});

--- a/e2e/specs/formsDashboard.spec.ts
+++ b/e2e/specs/formsDashboard.spec.ts
@@ -20,16 +20,21 @@ test("should filter forms based on publish status and the search value", async (
   page,
 }) => {
   const formBuilderPage = new FormBuilderPage(page);
-  await formBuilderPage.gotoFormBuilder();
+  await test.step("When I Visit the form builder dashboard", async () => {
+    await formBuilderPage.gotoFormBuilder();
+  });
 
   // Test the filter functionality
-  await page
-    .getByRole("button", { name: "Filter by publish status: All Open menu" })
-    .click();
-  await page.getByText("Unpublished").click();
+  await test.step("Then I click the publish filter dropdown and click Unpublished", async () => {
+    await page
+      .getByRole("button", { name: "Filter by publish status: All Open menu" })
+      .click();
+    await page.getByText("Unpublished").click();
+  });
 
   // Locate the table
-  await page.locator(".cds--data-table-container");
+  await test.step("When I locate the table", async () =>
+    await page.locator(".cds--data-table-container"));
 
   // Assert that only published forms are displayed in the table
   const filteredTableRows = await page.$$eval(
@@ -37,24 +42,27 @@ test("should filter forms based on publish status and the search value", async (
     (rows) => rows
   );
 
-  expect(filteredTableRows.length).toBeGreaterThanOrEqual(1);
-
   // Expect the publish status to be "No"
   const tagElement = await await page.$(`[data-testid="no-tag"]`);
 
   // Get the inner text of the tag element
   const innerText = await tagElement.innerText();
-
-  // Assert that the inner text is "No"
-  expect(innerText).toBe("No");
+  await test.step("Then the table should have row greater or equal to 1 and the Publish tag should be No", () => {
+    expect(filteredTableRows.length).toBeGreaterThanOrEqual(1);
+    expect(innerText).toBe("No");
+  });
 });
 
 test("should search forms by name", async ({ page }) => {
   const formBuilderPage = new FormBuilderPage(page);
-  await formBuilderPage.gotoFormBuilder();
+  await test.step("When I Visit the form builder dashboard", async () => {
+    await formBuilderPage.gotoFormBuilder();
+  });
 
-  await page.getByPlaceholder("Search this list").click();
-  await page.getByPlaceholder("Search this list").fill("ui select");
+  await test.step("Then I click the search button and type 'form created' in the search field", async () => {
+    await page.getByPlaceholder("Search this list").click();
+    await page.getByPlaceholder("Search this list").fill("form created");
+  });
 
   // Wait for the table to update with filtered results
   await page.locator(".cds--data-table-container");
@@ -64,11 +72,13 @@ test("should search forms by name", async ({ page }) => {
     (rows) => rows
   );
 
-  expect(searchedTableRows.length).toBeGreaterThanOrEqual(1);
   const formNameElement = await page.locator("tr:nth-child(1) > td").nth(0);
-
   const innerNameText = await formNameElement.innerText();
-  expect(innerNameText).toContain("UI Select");
+
+  await test.step("When I locate the table, it should have atleast 1 row with the form name containing 'Form created'", () => {
+    expect(searchedTableRows.length).toBeGreaterThanOrEqual(1);
+    expect(innerNameText).toContain("Form created");
+  });
 });
 
 test.afterEach(async ({ api }) => {

--- a/e2e/specs/formsDashboard.spec.ts
+++ b/e2e/specs/formsDashboard.spec.ts
@@ -13,7 +13,6 @@ test("should filter forms based on publish status", async ({ page }) => {
 
   // Inputs the dummy schema
   await formBuilderPage.inputDummySchemaButton().click();
-  // await formBuilderPage.renderChangesButton().click();
 
   // Save the form
   await formBuilderPage.saveForm();
@@ -26,22 +25,19 @@ test("should filter forms based on publish status", async ({ page }) => {
   await formBuilderPage.publishedOption().click();
 
   // Wait for the table to update with filtered results
-  await formBuilderPage.tableContainer();
+  await page.locator(".cds--data-table-container");
 
   // Assert that only published forms are displayed in the table
   const tableRows = await page.$$eval(
-    ".cds--data-table tbody tr",
+    '[data-testid^="form-row-"]',
     (rows) => rows
   );
 
   expect(tableRows.length).toBeGreaterThan(1);
 
-  const tableRow = await page.$(".cds--data-table tbody tr");
-  const thirdTdElement = await tableRow.evaluateHandle((row) =>
-    row.querySelector("td:nth-child(3)")
-  );
+  const row = await page.$(`[data-testid="form-row-0"]`);
+  const thirdTdElement = await row.$("td:nth-child(3)");
 
-  // Locate the <div> element with the publish status tag
   const publishStatusTag = await thirdTdElement.$(".cds--tag");
 
   // Get the text content of the publish status tag
@@ -76,11 +72,11 @@ test("should search forms by name", async ({ page }) => {
 
   await formBuilderPage.searchbox().type("Sample Form");
 
-  await formBuilderPage.tableContainer();
+  await page.locator(".cds--data-table-container");
 
   // Assert that only published forms are displayed in the table
   const tableRows = await page.$$eval(
-    ".cds--data-table tbody tr",
+    '[data-testid^="form-row-"]',
     (rows) => rows
   );
 
@@ -90,7 +86,7 @@ test("should search forms by name", async ({ page }) => {
     .getAttribute("value");
   expect(searchBoxValue).toBe("Sample Form");
 
-  const tableRow = await page.$(".cds--data-table tbody tr");
+  const tableRow = await page.$(`[data-testid="form-row-1"]`);
   const tdElement = await tableRow.$("td");
   const tdNameTextContent = await tdElement.textContent();
 

--- a/e2e/specs/formsDashboard.spec.ts
+++ b/e2e/specs/formsDashboard.spec.ts
@@ -33,10 +33,11 @@ test("Filter forms based on publish status", async ({ page }) => {
     await page.getByText("Unpublished").click());
 
   // Expect the publish status to be "No"
-  const tagElement = await page.getByTestId(`[data-testid="no-tag"]`);
+  const tagElements = await page.$$('div[data-testid="no-tag"]');
+  const firstTagElement = tagElements[0];
 
   // Get the inner text of the tag element
-  const innerText = await tagElement.innerText();
+  const innerText = await firstTagElement.innerText();
   await test.step("Then the form table should have only the unpublished forms", () => {
     expect(innerText).toBe("No");
   });

--- a/e2e/specs/formsDashboard.spec.ts
+++ b/e2e/specs/formsDashboard.spec.ts
@@ -16,67 +16,55 @@ test.beforeEach(async ({ api }) => {
   await addFormResources(api, valueReference, form.uuid);
 });
 
-test("should filter forms based on publish status and the search value", async ({
-  page,
-}) => {
+test("Filter forms based on publish status", async ({ page }) => {
   const formBuilderPage = new FormBuilderPage(page);
   await test.step("When I Visit the form builder dashboard", async () => {
     await formBuilderPage.gotoFormBuilder();
   });
 
   // Test the filter functionality
-  await test.step("Then I click the publish filter dropdown and click Unpublished", async () => {
+  await test.step("Then I click the publish filter dropdown", async () => {
     await page
       .getByRole("button", { name: "Filter by publish status: All Open menu" })
       .click();
-    await page.getByText("Unpublished").click();
   });
 
-  // Locate the table
-  await test.step("When I locate the table", async () =>
-    await page.locator(".cds--data-table-container"));
+  await test.step("And I click the Unplished option", async () =>
+    await page.getByText("Unpublished").click());
 
-  // Assert that only published forms are displayed in the table
-  const filteredTableRows = await page.$$eval(
-    ".cds--data-table tbody tr",
-    (rows) => rows
-  );
+  // Locate the table
+  await page.$('[data-testid ="forms-table"]');
 
   // Expect the publish status to be "No"
   const tagElement = await await page.$(`[data-testid="no-tag"]`);
 
   // Get the inner text of the tag element
   const innerText = await tagElement.innerText();
-  await test.step("Then the table should have row greater or equal to 1 and the Publish tag should be No", () => {
-    expect(filteredTableRows.length).toBeGreaterThanOrEqual(1);
+  await test.step("Then the form table should have only the unpublished forms", () => {
     expect(innerText).toBe("No");
   });
 });
 
-test("should search forms by name", async ({ page }) => {
+test("Search forms by name", async ({ page }) => {
   const formBuilderPage = new FormBuilderPage(page);
   await test.step("When I Visit the form builder dashboard", async () => {
     await formBuilderPage.gotoFormBuilder();
   });
 
-  await test.step("Then I click the search button and type 'form created' in the search field", async () => {
+  await test.step("Then I click the search button", async () => {
     await page.getByPlaceholder("Search this list").click();
-    await page.getByPlaceholder("Search this list").fill("form created");
   });
 
-  // Wait for the table to update with filtered results
-  await page.locator(".cds--data-table-container");
+  await test.step("And I type 'form created'", async () =>
+    await page.getByPlaceholder("Search this list").fill("form created"));
 
-  const searchedTableRows = await page.$$eval(
-    ".cds--data-table tbody tr",
-    (rows) => rows
-  );
+  // Wait for the table to update with filtered results
+  await page.$('[data-testid ="forms-table"]');
 
   const formNameElement = await page.locator("tr:nth-child(1) > td").nth(0);
   const innerNameText = await formNameElement.innerText();
 
-  await test.step("When I locate the table, it should have atleast 1 row with the form name containing 'Form created'", () => {
-    expect(searchedTableRows.length).toBeGreaterThanOrEqual(1);
+  await test.step("Then the form table should show only the forms containing the name 'Form created'", () => {
     expect(innerNameText).toContain("Form created");
   });
 });

--- a/e2e/specs/formsDashboard.spec.ts
+++ b/e2e/specs/formsDashboard.spec.ts
@@ -32,11 +32,8 @@ test("Filter forms based on publish status", async ({ page }) => {
   await test.step("And I click the Unplished option", async () =>
     await page.getByText("Unpublished").click());
 
-  // Locate the table
-  await page.$('[data-testid ="forms-table"]');
-
   // Expect the publish status to be "No"
-  const tagElement = await await page.$(`[data-testid="no-tag"]`);
+  const tagElement = await page.getByTestId(`[data-testid="no-tag"]`);
 
   // Get the inner text of the tag element
   const innerText = await tagElement.innerText();
@@ -57,9 +54,6 @@ test("Search forms by name", async ({ page }) => {
 
   await test.step("And I type 'form created'", async () =>
     await page.getByPlaceholder("Search this list").fill("form created"));
-
-  // Wait for the table to update with filtered results
-  await page.$('[data-testid ="forms-table"]');
 
   const formNameElement = await page.locator("tr:nth-child(1) > td").nth(0);
   const innerNameText = await formNameElement.innerText();

--- a/src/components/dashboard/dashboard.component.tsx
+++ b/src/components/dashboard/dashboard.component.tsx
@@ -386,7 +386,10 @@ function FormsList({ forms, isValidating, mutate, t }: FormsListProps) {
       >
         {({ rows, headers, getTableProps, getHeaderProps, getRowProps }) => (
           <>
-            <TableContainer className={styles.tableContainer}>
+            <TableContainer
+              className={styles.tableContainer}
+              data-testid="forms-table"
+            >
               <div className={styles.toolbarWrapper}>
                 <TableToolbar className={styles.tableToolbar}>
                   <TableToolbarContent>
@@ -421,7 +424,10 @@ function FormsList({ forms, isValidating, mutate, t }: FormsListProps) {
                 </TableHead>
                 <TableBody>
                   {rows.map((row, i) => (
-                    <TableRow {...getRowProps({ row })}>
+                    <TableRow
+                      {...getRowProps({ row })}
+                      data-testid={`form-row-${row.id}`}
+                    >
                       {row.cells.map((cell) => (
                         <TableCell key={cell.id}>{cell.value}</TableCell>
                       ))}

--- a/src/components/dashboard/dashboard.component.tsx
+++ b/src/components/dashboard/dashboard.component.tsx
@@ -420,8 +420,11 @@ function FormsList({ forms, isValidating, mutate, t }: FormsListProps) {
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {rows.map((row) => (
-                    <TableRow {...getRowProps({ row })}>
+                  {rows.map((row, i) => (
+                    <TableRow
+                      {...getRowProps({ row })}
+                      data-testid={`form-row-${i}`}
+                    >
                       {row.cells.map((cell) => (
                         <TableCell key={cell.id}>{cell.value}</TableCell>
                       ))}

--- a/src/components/dashboard/dashboard.component.tsx
+++ b/src/components/dashboard/dashboard.component.tsx
@@ -76,14 +76,14 @@ function CustomTag({ condition }: { condition: boolean }) {
 
   if (condition) {
     return (
-      <Tag type="green" size="md" title="Clear Filter">
+      <Tag type="green" size="md" title="Clear Filter" data-testid="yes-tag">
         {t("yes", "Yes")}
       </Tag>
     );
   }
 
   return (
-    <Tag type="red" size="md" title="Clear Filter">
+    <Tag type="red" size="md" title="Clear Filter" data-testid="no-tag">
       {t("no", "No")}
     </Tag>
   );
@@ -421,10 +421,7 @@ function FormsList({ forms, isValidating, mutate, t }: FormsListProps) {
                 </TableHead>
                 <TableBody>
                   {rows.map((row, i) => (
-                    <TableRow
-                      {...getRowProps({ row })}
-                      data-testid={`form-row-${i}`}
-                    >
+                    <TableRow {...getRowProps({ row })}>
                       {row.cells.map((cell) => (
                         <TableCell key={cell.id}>{cell.value}</TableCell>
                       ))}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
- This PR adds `e2e tests` for the search and filtering functionality on the form builder dashboard.

## Screenshots
- Recording

https://github.com/openmrs/openmrs-esm-form-builder/assets/30952856/4d3f14ed-4863-45ff-936d-fb5815298694


## Related Issue
- https://issues.openmrs.org/browse/O3-2119

