### PR TITLE
(fix) Remove the need to pass a `patientUuid` to the form engine

### DIFF
--- a/src/components/dashboard/dashboard.component.tsx
+++ b/src/components/dashboard/dashboard.component.tsx
@@ -41,13 +41,13 @@ import {
   usePagination,
 } from "@openmrs/esm-framework";
 
-import { deleteForm } from "../../forms.resource";
 import type { Form as FormType } from "../../types";
+import { FormBuilderPagination } from "../pagination";
+import { deleteForm } from "../../forms.resource";
 import { useClobdata } from "../../hooks/useClobdata";
 import { useForms } from "../../hooks/useForms";
 import EmptyState from "../empty-state/empty-state.component";
 import ErrorState from "../error-state/error-state.component";
-import { FormBuilderPagination } from "../pagination";
 import styles from "./dashboard.scss";
 
 function CustomTag({ condition }) {
@@ -240,9 +240,8 @@ function FormsList({ forms, isValidating, mutate, t }) {
   const isTablet = useLayoutType() === "tablet";
   const [filter, setFilter] = useState("");
   const config = useConfig();
-  const [pageSize, setPageSize] = useState(10);
-  const pageSizes = [10, 20, 30, 40, 50];
   const [searchString, setSearchString] = useState("");
+  const pageSize = 10;
 
   const filteredRows = useMemo(() => {
     if (!filter) {

--- a/src/components/form-renderer/form-renderer.component.tsx
+++ b/src/components/form-renderer/form-renderer.component.tsx
@@ -3,7 +3,6 @@ import { ErrorBoundary } from "react-error-boundary";
 import { useTranslation } from "react-i18next";
 import { Button, InlineLoading, Tile } from "@carbon/react";
 import { OHRIFormSchema, OHRIForm } from "@openmrs/openmrs-form-engine-lib";
-import { useConfig } from "@openmrs/esm-framework";
 
 import ActionButtons from "../action-buttons/action-buttons.component";
 import styles from "./form-renderer.scss";
@@ -16,7 +15,6 @@ type FormRendererProps = {
 
 const FormRenderer: React.FC<FormRendererProps> = ({ isLoading, schema }) => {
   const { t } = useTranslation();
-  const { patientUuid } = useConfig();
 
   const dummySchema: OHRIFormSchema = {
     encounterType: "",
@@ -91,7 +89,7 @@ const FormRenderer: React.FC<FormRendererProps> = ({ isLoading, schema }) => {
             <OHRIForm
               formJson={schemaToRender}
               mode={"enter"}
-              patientUUID={patientUuid}
+              patientUUID={""}
             />
           </ErrorBoundary>
         )}

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -38,12 +38,6 @@ export const configSchema = {
       "ui-select-extended",
     ],
   },
-  patientUuid: {
-    _type: "String",
-    _default: "0fffdcc6-ee28-49ed-a6fc-947309218f27",
-    _description:
-      "UUID of the test patient whose information gets rendered in a patient banner within the form renderer",
-  },
   showSchemaSaveWarning: {
     _type: Type.Boolean,
     _default: true,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR removes the need to configure a `patientUuid` property in the form builder. Typically, the form builder gets used outside of a patient context (like the patient chart). So, requiring the form builder to provide a `patientUuid` that can get used to construct a payload or render patient information in a banner isn't ideal. The workaround in place involves providing a `patientUuid` through the configuration schema that matches that of a known test patient. This is suboptimal and brittle, and it's currently **failing in production** because the provided test patient does not exist. 

This PR provides an empty string as the `patientUuid` parameter to the `OHRIForm` component. The form engine will pass this string to `usePatient`, which will fail gracefully and attempt to fetch the `patientUuid` from the page URL. When that fails too, `usePatient` will return null as the value of the patient object, which effectively short circuits the logic needed to render the patient banner. Something that does get affected is the submission of encounters from the form engine, but I don't know that we're handling that explicitly. Ideally, I'd expect that if we submit a form via the form builder, the user can at least get to see the payload. That way, they could see how their responses would look once a form gets submitted. So that should be presented to the user in a friendly way, rather than having them mine through the network tab. 

Finally, this PR also removes some cruft from the `Dashboard` component.