### PR TITLE
(chore) Add a link to the form builder to the system admin interstitial page

### DIFF
--- a/src/form-builder-admin-card-link.component.tsx
+++ b/src/form-builder-admin-card-link.component.tsx
@@ -12,7 +12,7 @@ const FormBuilderCardLink: React.FC = () => {
         id={`clickable-tile-${header}`}
         href={`${window.spaBase}/form-builder`}
         target="_blank"
-        rel="no-refferer"
+        rel="noopener noreferrer"
       >
         <div>
           <div className="heading">{header}</div>

--- a/src/form-builder-admin-card-link.component.tsx
+++ b/src/form-builder-admin-card-link.component.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { Layer, ClickableTile } from "@carbon/react";
+import { ArrowRight } from "@carbon/react/icons";
+
+const FormBuilderCardLink: React.FC = () => {
+  const { t } = useTranslation();
+  const header = t("manageForms", "Manage Forms");
+  return (
+    <Layer>
+      <ClickableTile
+        id={`clickable-tile-${header}`}
+        href={`${window.spaBase}/form-builder`}
+        target="_blank"
+        rel="no-refferer"
+      >
+        <div>
+          <div className="heading">{header}</div>
+          <div className="content">{t("formBuilder", "Form Builder")}</div>
+        </div>
+        <div className="iconWrapper">
+          <ArrowRight size={16} />
+        </div>
+      </ClickableTile>
+    </Layer>
+  );
+};
+
+export default FormBuilderCardLink;

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,16 @@ function setupOpenMRS() {
         online: true,
         offline: true,
       },
+      {
+        id: "system-administration-form-builder-card-link",
+        slot: "system-admin-page-card-link-slot",
+        load: getAsyncLifecycle(
+          () => import("./form-builder-admin-card-link.component"),
+          options
+        ),
+        online: true,
+        offline: true,
+      },
     ],
   };
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
- This PR adds a form builder card link to the `system-admin-cards-link-slot` which is implemented in this [PR](https://github.com/openmrs/openmrs-esm-admin-tools/pull/21). So it depends on the mentioned PR being merged first.


## Related Issue
- Linked to this issue https://issues.openmrs.org/browse/O3-2126

