### PR TITLE
O3-2135: (fix) Unable to set form name and version

### DIFF
--- a/src/components/action-buttons/action-buttons.component.tsx
+++ b/src/components/action-buttons/action-buttons.component.tsx
@@ -14,7 +14,7 @@ import type { TFunction } from "react-i18next";
 import type { RouteParams, Schema } from "../../types";
 import { publishForm, unpublishForm } from "../../forms.resource";
 import { useForm } from "../../hooks/useForm";
-import SaveForm from "../modals/save-form.component";
+import SaveFormModal from "../modals/save-form.component";
 import styles from "./action-buttons.scss";
 
 type Status =
@@ -97,7 +97,7 @@ function ActionButtons({ schema, t }: ActionButtonsProps) {
 
   return (
     <div className={styles.actionButtons}>
-      <SaveForm form={form} schema={schema} />
+      <SaveFormModal form={form} schema={schema} />
 
       <>
         {form && !form.published ? (

--- a/src/components/modals/save-form.component.tsx
+++ b/src/components/modals/save-form.component.tsx
@@ -45,7 +45,7 @@ type SaveFormModalProps = {
   schema: Schema;
 };
 
-const SaveForm: React.FC<SaveFormModalProps> = ({ form, schema }) => {
+const SaveFormModal: React.FC<SaveFormModalProps> = ({ form, schema }) => {
   const { t } = useTranslation();
   const { formUuid } = useParams<RouteParams>();
   const { mutate } = useForm(formUuid);
@@ -198,6 +198,8 @@ const SaveForm: React.FC<SaveFormModalProps> = ({ form, schema }) => {
                           });
                           setOpenSaveFormModal(false);
                           mutate();
+
+                          setIsSavingForm(false);
                         })
                         .catch((err) => {
                           console.error(
@@ -227,8 +229,6 @@ const SaveForm: React.FC<SaveFormModalProps> = ({ form, schema }) => {
                   )
                 );
             });
-
-          setIsSavingForm(false);
         }
       } catch (error) {
         showNotification({
@@ -296,12 +296,12 @@ const SaveForm: React.FC<SaveFormModalProps> = ({ form, schema }) => {
             <FormGroup legendText={""}>
               <Stack gap={5}>
                 <TextInput
+                  defaultValue={schema?.name || form?.name}
                   id="name"
                   labelText={t("formName", "Form name")}
                   onChange={(event) => setName(event.target.value)}
                   placeholder="e.g. OHRI Express Care Patient Encounter Form"
                   required
-                  value={schema?.name || form?.name}
                 />
                 {saveState === "update" ? (
                   <TextInput
@@ -312,6 +312,7 @@ const SaveForm: React.FC<SaveFormModalProps> = ({ form, schema }) => {
                   />
                 ) : null}
                 <TextInput
+                  defaultValue={schema?.version || form?.version}
                   id="version"
                   labelText="Version"
                   placeholder="e.g. 1.0"
@@ -328,7 +329,6 @@ const SaveForm: React.FC<SaveFormModalProps> = ({ form, schema }) => {
                     "invalidVersionWarning",
                     "Version can only start with with a number"
                   )}
-                  value={schema?.version || form?.version}
                 />
                 <Select
                   id="encounterType"
@@ -405,4 +405,4 @@ const SaveForm: React.FC<SaveFormModalProps> = ({ form, schema }) => {
   );
 };
 
-export default SaveForm;
+export default SaveFormModal;

--- a/src/hooks/useClobdata.ts
+++ b/src/hooks/useClobdata.ts
@@ -9,7 +9,7 @@ export const useClobdata = (form?: Form) => {
   const formHasResources = form?.resources.length > 0 && valueReferenceUuid;
   const url = `/ws/rest/v1/clobdata/${valueReferenceUuid}`;
 
-  const { data, error, isLoading, mutate } = useSWRImmutable<
+  const { data, error, isLoading, isValidating, mutate } = useSWRImmutable<
     { data: Schema },
     Error
   >(formHasResources ? url : null, openmrsFetch);
@@ -18,6 +18,7 @@ export const useClobdata = (form?: Form) => {
     clobdata: data?.data,
     clobdataError: error || null,
     isLoadingClobdata: isLoading,
+    isValidatingClobdata: isValidating,
     mutate: mutate,
   };
 };

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -5,15 +5,16 @@ import type { Form } from "../types";
 export const useForm = (uuid: string) => {
   const url = `/ws/rest/v1/form/${uuid}?v=full`;
 
-  const { data, error, isLoading, mutate } = useSWR<{ data: Form }, Error>(
-    uuid ? url : null,
-    openmrsFetch
-  );
+  const { data, error, isLoading, isValidating, mutate } = useSWR<
+    { data: Form },
+    Error
+  >(uuid ? url : null, openmrsFetch);
 
   return {
     form: data?.data,
     formError: error,
     isLoadingForm: isLoading,
+    isValidatingForm: isValidating,
     mutate,
   };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export interface Form {
   description: string;
   published?: boolean;
   retired?: boolean;
-  formFields?: Array<unknown>;
+  formFields?: Array<string>;
   display?: string;
 }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR fixes a regression from #125 that prevents the user from modifying the `name` and `version` fields of the `Save Form` modal when saving a Form. Specifically, values from the JSON schema in the schema editor ought to be provided to the modal as `defaultValue` props to the `TextInput` components. The bug occurred because these values were provided as `value`s instead of `defaultValue`s (the distinction is [subtle](https://react.carbondesignsystem.com/?path=/story/components-textinput--default)), which essentially meant that there was no mechanism for changing them.

Additionally, this PR further tweaks the logic that handles when to show the `Load Draft Schema` modal. The original logic was brittle and could sometimes trigger rendering the modal in the wrong situation (e.g. during revalidation of the form and schema objects immediately after saving a form). It also adds missing `aria-labels` to a couple of `TabList` components.

## Screenshots

https://github.com/openmrs/openmrs-esm-form-builder/assets/8509731/706c507b-8dce-4ab9-a34e-a63b6ba489f1

## Related Issue

https://issues.openmrs.org/browse/O3-2135

## Other

Given how prone this workflow has been to regressions lately, it's probably best to write an end-to-end test for it. That test should accompany this PR, but this fix needs to go out sooner than I'd anticipated.
