### PR TITLE
(fix) Fix `MultiSelect` component rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "url": "https://github.com/openmrs/openmrs-esm-form-builder/issues"
   },
   "dependencies": {
-    "@carbon/react": "1.30.0",
+    "@carbon/react": "^1.31.0",
     "@openmrs/openmrs-form-engine-lib": "next",
     "dotenv": "^16.1.4",
     "file-loader": "^6.2.0",

--- a/src/components/interactive-builder/add-question-modal.component.tsx
+++ b/src/components/interactive-builder/add-question-modal.component.tsx
@@ -430,6 +430,7 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
 
               {answers && answers.length ? (
                 <MultiSelect
+                  className={styles.multiSelect}
                   direction="top"
                   id="selectAnswers"
                   itemToString={(item) => item.text}

--- a/src/components/interactive-builder/edit-question-modal.component.tsx
+++ b/src/components/interactive-builder/edit-question-modal.component.tsx
@@ -489,6 +489,7 @@ const EditQuestionModal: React.FC<EditQuestionModalProps> = ({
               questionToEdit?.questionOptions?.answers &&
               questionToEdit?.questionOptions.answers?.length ? (
                 <MultiSelect
+                  className={styles.multiSelect}
                   direction="top"
                   id="selectAnswers"
                   itemToString={(item) => item.text}
@@ -534,6 +535,7 @@ const EditQuestionModal: React.FC<EditQuestionModalProps> = ({
 
               {hasConceptChanged && answersFromConcept.length ? (
                 <MultiSelect
+                  className={styles.multiSelect}
                   direction="top"
                   id="selectAnswers"
                   itemToString={(item) => item.text}

--- a/src/components/interactive-builder/question-modal.scss
+++ b/src/components/interactive-builder/question-modal.scss
@@ -94,3 +94,13 @@
   }
 }
 
+.multiSelect {
+  :global(.cds--list-box__field--wrapper) {
+    align-items: center;
+    display: flex;
+    height: 2.5rem;
+    justify-content: space-between;
+    margin-left: 0.5rem;
+    width: 100%;
+  }
+}

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,6 +1,4 @@
 declare module "@carbon/react";
 declare module "*.css";
 declare module "*.scss";
-declare module "*.png";
-
-declare type SideNavProps = {};
+declare type SideNavProps = object;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1379,10 +1379,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/colors@npm:^11.15.0":
-  version: 11.15.0
-  resolution: "@carbon/colors@npm:11.15.0"
-  checksum: cf9ba33062dd6d7f132aeebb4025b2c6da01fca2bb6b23080eee1cd39e58a5fed6b5670298aa13bc08e93737726349246e7c0ef85569bcfccdf1bb3bcd8e26ca
+"@carbon/colors@npm:^11.16.0":
+  version: 11.16.0
+  resolution: "@carbon/colors@npm:11.16.0"
+  checksum: 13615d59cdfed8d2b951fcd2844a537c67239d6d60892d717207d0f723df30aa8452b2cc0f7f7083e558a713dfd103c02fe5087e22ffe408b8d194a2c34a5bb7
   languageName: node
   linkType: hard
 
@@ -1393,10 +1393,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/feature-flags@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@carbon/feature-flags@npm:0.14.0"
-  checksum: 6949630de92ca373d83164bc2e3f90ae43777f134e74dfc6780c6bda8c2bce666ed037ccdb8a91650d7dc2e9960a3ab21f291c704cb0a8f2dbde1851645d5f56
+"@carbon/feature-flags@npm:^0.15.0":
+  version: 0.15.0
+  resolution: "@carbon/feature-flags@npm:0.15.0"
+  checksum: 211827fec11ec29140ef783a025cc3b466c4f94bab7ca9a0f5eb0a84332919ca58f7a885813d4cdf441c9be0e998bc493a819c3c7124da1f24771ce65ab2c42c
   languageName: node
   linkType: hard
 
@@ -1407,12 +1407,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/grid@npm:^11.14.0":
-  version: 11.14.0
-  resolution: "@carbon/grid@npm:11.14.0"
+"@carbon/grid@npm:^11.15.0":
+  version: 11.15.0
+  resolution: "@carbon/grid@npm:11.15.0"
   dependencies:
-    "@carbon/layout": ^11.14.0
-  checksum: 9407d3bf132852eb0835bd269aab2497b8f531d9fd5df392bc02a15ce7bbf2d44b9a2426356eed8a537204a566fcbd928f85072884acab7dd1b18172c5d8203e
+    "@carbon/layout": ^11.15.0
+  checksum: 6c799d2f8ed63d5c63b9d80d98326c2d4cb16e1bfc5b587994d135635f501a08bcd0957f4a1f912932448c880f29a566c12b24b0834f28295946c65b329948fc
   languageName: node
   linkType: hard
 
@@ -1432,10 +1432,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/icon-helpers@npm:^10.40.0":
-  version: 10.40.0
-  resolution: "@carbon/icon-helpers@npm:10.40.0"
-  checksum: d45ef09d571cad2618eb5e4530b5360a9cc4ee688acfd13bda69ab4c982f7d5d146340bdcb7d40c8ce9f505c215cc0128e1018f8fca36ac9a1f823484749d281
+"@carbon/icon-helpers@npm:^10.41.0":
+  version: 10.41.0
+  resolution: "@carbon/icon-helpers@npm:10.41.0"
+  checksum: 0997b5db05aa3bb7cf1154b2446870bc4bea157199736b0ca1c85ba0c638f894466ebb7a0083a8e42420933a87939c7d4343025b0e8b8645dd0b0b5782a4a0a5
   languageName: node
   linkType: hard
 
@@ -1452,23 +1452,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/icons-react@npm:^11.20.0":
-  version: 11.20.0
-  resolution: "@carbon/icons-react@npm:11.20.0"
+"@carbon/icons-react@npm:^11.21.0":
+  version: 11.21.0
+  resolution: "@carbon/icons-react@npm:11.21.0"
   dependencies:
-    "@carbon/icon-helpers": ^10.40.0
+    "@carbon/icon-helpers": ^10.41.0
     "@carbon/telemetry": 0.1.0
     prop-types: ^15.7.2
   peerDependencies:
     react: ">=16"
-  checksum: 2eba1ad01bc17505a667077f63b4672f7ff9bd5031770944aa9e39252e4c7d2c6a2b2e0e7401c86c6f58e599726472ff8857570ef7f544f2d1e23be8af459216
+  checksum: b2e518062a3f0caa8c31d71b0a5e2b54b40e728c14afb1054c33e1d08d76a01ac8f910c624e621805b4f5bd8c16d1e7bbc49c79f8ab7dd63360d162c2fb89338
   languageName: node
   linkType: hard
 
-"@carbon/layout@npm:^11.14.0":
-  version: 11.14.0
-  resolution: "@carbon/layout@npm:11.14.0"
-  checksum: 40b1078d560ee9a047f25ff9d0f0cd0579996e92d3a3105b645c4d6ee204a1db528babcd81ceddf10468574ea9d2b37cb58b8d672f086e3a2c291b760295d91a
+"@carbon/layout@npm:^11.15.0":
+  version: 11.15.0
+  resolution: "@carbon/layout@npm:11.15.0"
+  checksum: a2aeb6710820a2a4a7ede670259ae1532921e169f9fe17db25e983c14610333d59bd35b7acdf44d65d6e30e750da067a45f79997dcc5feedb909f5cfc0f33bb3
   languageName: node
   linkType: hard
 
@@ -1479,10 +1479,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/motion@npm:^11.11.0":
-  version: 11.11.0
-  resolution: "@carbon/motion@npm:11.11.0"
-  checksum: ba518d8e0d094cf2cd3e93e06c27d0b7c0f456c8d178d28ca14bffeff3caf7c5edcdc01f7336a3480832f974bca5c8db8846400f0bcaf6bed0d215c1316dc2d6
+"@carbon/motion@npm:^11.12.0":
+  version: 11.12.0
+  resolution: "@carbon/motion@npm:11.12.0"
+  checksum: 6cda794f6da51d21a89ac7083df04bcbaa9e623155fdda934aa3df908dd290adc65f02ee0808e6943eace4eafe204bd65a6decbcf1958c0c6a3735f53be97723
   languageName: node
   linkType: hard
 
@@ -1490,39 +1490,6 @@ __metadata:
   version: 11.5.0
   resolution: "@carbon/motion@npm:11.5.0"
   checksum: a0c583ce0a9370beb08061463566a3b41c427190d297cdad1631384a27e241334640afdd246b9c0fca62f58d51e8a5b8c7954a234118195f403cd8c13c8a1f09
-  languageName: node
-  linkType: hard
-
-"@carbon/react@npm:1.30.0":
-  version: 1.30.0
-  resolution: "@carbon/react@npm:1.30.0"
-  dependencies:
-    "@babel/runtime": ^7.18.3
-    "@carbon/feature-flags": ^0.14.0
-    "@carbon/icons-react": ^11.20.0
-    "@carbon/layout": ^11.14.0
-    "@carbon/styles": ^1.30.0
-    "@carbon/telemetry": 0.1.0
-    classnames: 2.3.2
-    copy-to-clipboard: ^3.3.1
-    downshift: 5.2.1
-    flatpickr: 4.6.9
-    invariant: ^2.2.3
-    lodash.debounce: ^4.0.8
-    lodash.findlast: ^4.5.0
-    lodash.isequal: ^4.5.0
-    lodash.omit: ^4.5.0
-    lodash.throttle: ^4.1.1
-    prop-types: ^15.7.2
-    react-is: ^18.2.0
-    use-resize-observer: ^6.0.0
-    wicg-inert: ^3.1.1
-    window-or-global: ^1.0.1
-  peerDependencies:
-    react: ^16.8.6 || ^17.0.1 || ^18.2.0
-    react-dom: ^16.8.6 || ^17.0.1 || ^18.2.0
-    sass: ^1.33.0
-  checksum: 197f7aa0f2cb16b34a5230bddf3a81c348413265f606e76dc06e709f94953935f7937a6c23421db5888f435f036d56616e25c8e141d29ff0d148ff687af9f1a6
   languageName: node
   linkType: hard
 
@@ -1559,6 +1526,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@carbon/react@npm:^1.31.0":
+  version: 1.31.2
+  resolution: "@carbon/react@npm:1.31.2"
+  dependencies:
+    "@babel/runtime": ^7.18.3
+    "@carbon/feature-flags": ^0.15.0
+    "@carbon/icons-react": ^11.21.0
+    "@carbon/layout": ^11.15.0
+    "@carbon/styles": ^1.31.1
+    "@carbon/telemetry": 0.1.0
+    classnames: 2.3.2
+    copy-to-clipboard: ^3.3.1
+    downshift: 5.2.1
+    flatpickr: 4.6.9
+    invariant: ^2.2.3
+    lodash.debounce: ^4.0.8
+    lodash.findlast: ^4.5.0
+    lodash.isequal: ^4.5.0
+    lodash.omit: ^4.5.0
+    lodash.throttle: ^4.1.1
+    prop-types: ^15.7.2
+    react-is: ^18.2.0
+    use-resize-observer: ^6.0.0
+    wicg-inert: ^3.1.1
+    window-or-global: ^1.0.1
+  peerDependencies:
+    react: ^16.8.6 || ^17.0.1 || ^18.2.0
+    react-dom: ^16.8.6 || ^17.0.1 || ^18.2.0
+    sass: ^1.33.0
+  checksum: fd9e9a8cbe2adb9702f1388befcef13261fe53f38e5fe80cec77172bd341ceea70059443fabcfdea3dab57f695b888a01cae3a5b6ccfccac73d48aed5dcd6731
+  languageName: node
+  linkType: hard
+
 "@carbon/styles@npm:^1.17.0, @carbon/styles@npm:^1.4.0":
   version: 1.17.0
   resolution: "@carbon/styles@npm:1.17.0"
@@ -1577,21 +1577,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/styles@npm:^1.30.0":
-  version: 1.30.0
-  resolution: "@carbon/styles@npm:1.30.0"
+"@carbon/styles@npm:^1.31.1":
+  version: 1.31.1
+  resolution: "@carbon/styles@npm:1.31.1"
   dependencies:
-    "@carbon/colors": ^11.15.0
-    "@carbon/feature-flags": ^0.14.0
-    "@carbon/grid": ^11.14.0
-    "@carbon/layout": ^11.14.0
-    "@carbon/motion": ^11.11.0
-    "@carbon/themes": ^11.19.0
-    "@carbon/type": ^11.18.0
+    "@carbon/colors": ^11.16.0
+    "@carbon/feature-flags": ^0.15.0
+    "@carbon/grid": ^11.15.0
+    "@carbon/layout": ^11.15.0
+    "@carbon/motion": ^11.12.0
+    "@carbon/themes": ^11.20.0
+    "@carbon/type": ^11.19.0
     "@ibm/plex": 6.0.0-next.6
   peerDependencies:
     sass: ^1.33.0
-  checksum: 76b4c90e38c81a3b275b0ebc8253c24bc0ed2a6dbef7d52a1bcb930eedb6eecdd3f83ace1784e20b803b0e5d3cc96311e42a9ef73a48135be3aac0482b5030bc
+  checksum: 309c5d5b22f8813a5cb5624345a290ac34b9e24151ee2270618ad3e545600243347da2bfab0d7bab6c0ee32461dbf9332010e612a72db4a0e07e0db29c256d0c
   languageName: node
   linkType: hard
 
@@ -1616,15 +1616,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/themes@npm:^11.19.0":
-  version: 11.19.0
-  resolution: "@carbon/themes@npm:11.19.0"
+"@carbon/themes@npm:^11.20.0":
+  version: 11.20.0
+  resolution: "@carbon/themes@npm:11.20.0"
   dependencies:
-    "@carbon/colors": ^11.15.0
-    "@carbon/layout": ^11.14.0
-    "@carbon/type": ^11.18.0
+    "@carbon/colors": ^11.16.0
+    "@carbon/layout": ^11.15.0
+    "@carbon/type": ^11.19.0
     color: ^4.0.0
-  checksum: e4d6ad63b020a1108185967f93b85dd34a7b4b4f37c8ae4f632d611df0accfd2a6ca3df5f864d8c87483a58ffdec0e887da6cc2e96bc3d044bd66c58c3820c48
+  checksum: 515b90b13082d12f1e4bb8a3af9302593107ebdcc99cce2fc2db9b9f40590fa3332a21478906b9af5bff9ebc103e2b0308b9d1cc41ce9d1e83a29d22463ba2de
   languageName: node
   linkType: hard
 
@@ -1638,13 +1638,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/type@npm:^11.18.0":
-  version: 11.18.0
-  resolution: "@carbon/type@npm:11.18.0"
+"@carbon/type@npm:^11.19.0":
+  version: 11.19.0
+  resolution: "@carbon/type@npm:11.19.0"
   dependencies:
-    "@carbon/grid": ^11.14.0
-    "@carbon/layout": ^11.14.0
-  checksum: 3bfa1a2c2dd138a15510bda15ff4d843d4437f2437cbede6336fba7e96f141d84e769d3e4e7802bf2e5d94104572f172749c03ec8bac554b3a71537810b48b34
+    "@carbon/grid": ^11.15.0
+    "@carbon/layout": ^11.15.0
+  checksum: 8bd9e9d0745466fa54f00d2b128fcd0eb340b12e7d24bd7834ef2ee5b87c4314d222008b8478fe982129902a780d7de3de5b9cc0d81c0b6f5fbc8d6a4d8d2d33
   languageName: node
   linkType: hard
 
@@ -2798,7 +2798,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-form-builder-app@workspace:."
   dependencies:
-    "@carbon/react": 1.30.0
+    "@carbon/react": ^1.31.0
     "@openmrs/esm-framework": next
     "@openmrs/esm-styleguide": next
     "@openmrs/openmrs-form-engine-lib": next


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR fixes an issue where the Carbon [MultiSelect](https://react.carbondesignsystem.com/?path=/docs/components-multiselect--default) component does not render correctly. I've added style overrides to the `.cds--list-box__field--wrapper` class that ensures the component renders correctly. I'm yet to establish the root cause of this regression - it could be down to upgrading to the latest version of Carbon (which I think is unlikely), or recent style overrides added to `esm-core`.

This PR also renames the `declarations.d.tsx` file, dropping the `.tsx` extension.

## Video

> Before

https://github.com/openmrs/openmrs-esm-form-builder/assets/8509731/915e5e60-bcc4-4047-b048-9bd92476e4bd

> After

https://github.com/openmrs/openmrs-esm-form-builder/assets/8509731/8cfef889-8532-49eb-9feb-56e4c445ae98



