### PR TITLE
O3-2200: Utilize form search functionality in E2E tests

### DIFF
--- a/e2e/commands/form-operations.ts
+++ b/e2e/commands/form-operations.ts
@@ -7,7 +7,7 @@ export const createForm = async (
 ) => {
   const formResponse = await api.post("form", {
     data: {
-      name: "A sample test form",
+      name: `A sample test form ${Math.floor(Math.random() * 10000)}`,
       version: "1.0",
       published: isFormPublished,
       description: "This is the form description",

--- a/e2e/pages/form-builder-page.ts
+++ b/e2e/pages/form-builder-page.ts
@@ -134,4 +134,8 @@ export class FormBuilderPage {
     await this.formEncounterType().selectOption("Admission");
     await this.formSaveButton().click();
   }
+
+  async searchForm(formName: string) {
+    await this.page.getByRole('searchbox').fill(formName);
+  }
 }

--- a/e2e/specs/edit-existing-form.spec.ts
+++ b/e2e/specs/edit-existing-form.spec.ts
@@ -28,7 +28,7 @@ test("Editing an existing form", async ({ page }) => {
   });
 
   await test.step("And I click the `Edit` button on the form I need to edit", async () => {
-    await page.getByTestId(`editSchema${form.uuid}`).click();
+    await page.getByRole('row', { name: form.name }).getByRole('button').first().click();
   });
 
   await test.step("Then I click the `Save Form` button then the `Update existing version` button, and finally the `Save` button", async () => {

--- a/e2e/specs/edit-existing-form.spec.ts
+++ b/e2e/specs/edit-existing-form.spec.ts
@@ -28,7 +28,7 @@ test("Editing an existing form", async ({ page }) => {
   });
 
   await test.step("And I click the `Edit` button on the form I need to edit", async () => {
-    await page.getByRole('row', { name: form.name }).getByRole('button').first().click();
+    await page.getByRole('row', { name: form.name }).getByLabel('Edit Schema').click();
   });
 
   await test.step("Then I click the `Save Form` button then the `Update existing version` button, and finally the `Save` button", async () => {

--- a/e2e/specs/edit-existing-form.spec.ts
+++ b/e2e/specs/edit-existing-form.spec.ts
@@ -23,7 +23,11 @@ test("Editing an existing form", async ({ page }) => {
     await formBuilderPage.gotoFormBuilder();
   });
 
-  await test.step("And I click the `Edit` button on an existing form", async () => {
+  await test.step("And I search for the form I need to edit", async () => {
+    await formBuilderPage.searchForm(form.name);
+  });
+
+  await test.step("And I click the `Edit` button on the form I need to edit", async () => {
     await page.getByTestId(`editSchema${form.uuid}`).click();
   });
 

--- a/e2e/specs/publish-form.spec.ts
+++ b/e2e/specs/publish-form.spec.ts
@@ -28,7 +28,7 @@ test("Publish a form", async ({ page }) => {
   });
 
   await test.step("And I click on a form I need to publish", async () => {
-    await page.getByTestId(`editSchema${form.uuid}`).click();
+    await page.getByRole('row', { name: form.name }).getByRole('button').first().click();
   });
 
   await test.step("Then I click on the publish form button", async () => {

--- a/e2e/specs/publish-form.spec.ts
+++ b/e2e/specs/publish-form.spec.ts
@@ -28,7 +28,7 @@ test("Publish a form", async ({ page }) => {
   });
 
   await test.step("And I click on a form I need to publish", async () => {
-    await page.getByRole('row', { name: form.name }).getByRole('button').first().click();
+    await page.getByRole('row', { name: form.name }).getByLabel('Edit Schema').click();
   });
 
   await test.step("Then I click on the publish form button", async () => {

--- a/e2e/specs/publish-form.spec.ts
+++ b/e2e/specs/publish-form.spec.ts
@@ -23,6 +23,10 @@ test("Publish a form", async ({ page }) => {
     await formBuilderPage.gotoFormBuilder();
   });
 
+  await test.step("And I search for the form I need to publish", async () => {
+    await formBuilderPage.searchForm(form.name);
+  });
+
   await test.step("And I click on a form I need to publish", async () => {
     await page.getByTestId(`editSchema${form.uuid}`).click();
   });

--- a/e2e/specs/unpublish-form.spec.ts
+++ b/e2e/specs/unpublish-form.spec.ts
@@ -28,7 +28,7 @@ test("Unpublish a form", async ({ page }) => {
   });
 
   await test.step("And I click on a form I need to unpublish", async () => {
-    await page.getByRole('row', { name: form.name }).getByRole('button').first().click();
+    await page.getByRole('row', { name: form.name }).getByLabel('Edit Schema').click();
   });
 
   await test.step("Then I click on the unpublish form button and confirms the unpublication", async () => {

--- a/e2e/specs/unpublish-form.spec.ts
+++ b/e2e/specs/unpublish-form.spec.ts
@@ -28,7 +28,7 @@ test("Unpublish a form", async ({ page }) => {
   });
 
   await test.step("And I click on a form I need to unpublish", async () => {
-    await page.getByTestId(`editSchema${form.uuid}`).click();
+    await page.getByRole('row', { name: form.name }).getByRole('button').first().click();
   });
 
   await test.step("Then I click on the unpublish form button and confirms the unpublication", async () => {

--- a/e2e/specs/unpublish-form.spec.ts
+++ b/e2e/specs/unpublish-form.spec.ts
@@ -23,6 +23,10 @@ test("Unpublish a form", async ({ page }) => {
     await formBuilderPage.gotoFormBuilder();
   });
 
+  await test.step("And I search for the form I need to unpublish", async () => {
+    await formBuilderPage.searchForm(form.name);
+  });
+
   await test.step("And I click on a form I need to unpublish", async () => {
     await page.getByTestId(`editSchema${form.uuid}`).click();
   });

--- a/src/components/dashboard/dashboard.component.tsx
+++ b/src/components/dashboard/dashboard.component.tsx
@@ -153,7 +153,6 @@ function ActionButtons({ form, mutate, t }: ActionButtonsProps) {
       <Button
         enterDelayMs={300}
         renderIcon={Edit}
-        data-testid={`editSchema${form.uuid}`}
         onClick={() =>
           navigate({
             to: `${window.spaBase}/form-builder/edit/${form.uuid}`,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
Now the tests are using the form search functionality when looking for a form in E2E tests.
Also added a random number suffix to the form name, to reduce the chance of creating forms with the same name.

## Screenshots
<!-- Required if you are making UI changes. -->
<img width="598" alt="image" src="https://github.com/openmrs/openmrs-esm-form-builder/assets/27498587/7277cf18-591d-4497-a8ff-8596f7c242d9">

<br>
<img width="50%" alt="image" src="https://github.com/openmrs/openmrs-esm-form-builder/assets/27498587/6a26bffa-6cc4-431c-a711-83e1ac1ad933">

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-2200

## Other
<!-- Anything not covered above -->
There is a separate test case written to test the search functionality.