### PR TITLE
(fix) Change the DOM order of the form builder page

### DIFF
--- a/src/form-builder-admin-card-link.component.tsx
+++ b/src/form-builder-admin-card-link.component.tsx
@@ -9,7 +9,6 @@ const FormBuilderCardLink: React.FC = () => {
   return (
     <Layer>
       <ClickableTile
-        id={`clickable-tile-${header}`}
         href={`${window.spaBase}/form-builder`}
         target="_blank"
         rel="noopener noreferrer"

--- a/src/routes.json
+++ b/src/routes.json
@@ -10,7 +10,7 @@
       "route": "form-builder",
       "online": true,
       "offline": true,
-      "order": 0
+      "order": 1
     }
   ],
   "extensions": [


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR changes the `order` property of this frontend module's `root` page so it gets rendered after the primary navigation menu.
