### PR TITLE
(bug) O3-2230: error when the label for multiselect is not specified

### DIFF
--- a/src/components/interactive-builder/edit-question-modal.component.tsx
+++ b/src/components/interactive-builder/edit-question-modal.component.tsx
@@ -502,7 +502,7 @@ const EditQuestionModal: React.FC<EditQuestionModalProps> = ({
                   items={questionToEdit?.questionOptions?.answers?.map(
                     (answer) => ({
                       id: answer.concept,
-                      text: answer.label,
+                      text: answer.label ?? "",
                     })
                   )}
                   onChange={({ selectedItems }) => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
There was a bug that crashes the entire page in the interactive builder. When only the concept is specified in the configuration without a label, the page crashes when clicking on the multi-select due to accessing an undefined label

## Screenshots
Before
![image](https://github.com/openmrs/openmrs-esm-form-builder/assets/68945262/92bc49ea-4124-4f5c-adc5-5d103e654b88)
After
![image](https://github.com/openmrs/openmrs-esm-form-builder/assets/68945262/db689b8c-156b-4dd0-8a26-67ad75c44989)


## Related Issue
https://issues.openmrs.org/browse/O3-2230

## Other
<!-- Anything not covered above -->
