### PR TITLE
(enhancement) Replace direct href link with OpenMRS navigate function  in FormBuilderCardLink

### DIFF
--- a/src/form-builder-admin-card-link.component.tsx
+++ b/src/form-builder-admin-card-link.component.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { Layer, ClickableTile } from "@carbon/react";
 import { ArrowRight } from "@carbon/react/icons";
+import { navigate } from "@openmrs/esm-framework";
 
 const FormBuilderCardLink: React.FC = () => {
   const { t } = useTranslation();
@@ -9,9 +10,7 @@ const FormBuilderCardLink: React.FC = () => {
   return (
     <Layer>
       <ClickableTile
-        href={`${window.spaBase}/form-builder`}
-        target="_blank"
-        rel="noopener noreferrer"
+        onClick={() => navigate({ to: `\${openmrsSpaBase}/form-builder` })}
       >
         <div>
           <div className="heading">{header}</div>

--- a/src/form-builder-admin-card.test.tsx
+++ b/src/form-builder-admin-card.test.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import FormBuilderCardLink from "./form-builder-admin-card-link.component";
+import { navigate } from "@openmrs/esm-framework";
+import userEvent from '@testing-library/user-event'
+
+const navigateMock = navigate as jest.Mock;
+
+jest.mock("@openmrs/esm-framework", () => ({
+    navigate: jest.fn(),
+}));
+
+describe("FormBuilderCardLink", () => {
+    it("renders the header and content correctly", () => {
+        const { getByText } = render(<FormBuilderCardLink />);
+        const header = getByText("Manage Forms");
+        const content = getByText("Form Builder");
+        expect(header).toBeInTheDocument();
+        expect(content).toBeInTheDocument();
+    });
+
+    it("navigates when the clickable tile is clicked", async () => {
+        const { getByText } = render(<FormBuilderCardLink />);
+        const clickableTile = getByText("Manage Forms");
+    
+        userEvent.click(clickableTile);
+        await waitFor(() => expect(navigateMock).toBeCalledWith({ to: `\${openmrsSpaBase}/form-builder` }));
+    });
+});


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
Replace direct href link with OpenMRS navigate function  in `FormBuilderCardLink` the reason being `navigate` doesn't trigger a full page reload.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
