### PR TITLE
(fix) Remove unused `formBuilderAppMenuLink` extension

### DIFF
--- a/src/routes.json
+++ b/src/routes.json
@@ -15,13 +15,6 @@
   ],
   "extensions": [
     {
-      "name": "form-builder-app-menu-link",
-      "slot": "app-menu-slot",
-      "component": "formBuilderAppMenuLink",
-      "online": true,
-      "offline": true
-    },
-    {
       "name": "system-administration-form-builder-card-link",
       "slot": "system-admin-page-card-link-slot",
       "component": "systemAdministrationFormBuilderCardLink",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR removes an unused extension definition that should have been cleaned up in #151.

## Screenshots

<img width="571" alt="Screenshot 2023-07-10 at 10 33 54 AM" src="https://github.com/openmrs/openmrs-esm-form-builder/assets/8509731/8f4043fa-e79b-49d0-b7df-12bc9cb26b91">

## Related Issue
*None*
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
*None*
<!-- Anything not covered above -->
