### PR TITLE
(chore) Release `v2.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-form-builder-app",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "license": "MPL-2.0",
   "description": "OpenMRS ESM Form Builder App",
   "browser": "dist/openmrs-esm-form-builder-app.js",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR cuts a new `major` release of Form Builder `v2.0.0` that introduces a BREAKING change. It migrates this frontend module to leverage the new module loading mechanism introduced in [Core v5](https://github.com/openmrs/openmrs-esm-core/releases/tag/v5.0.0).

## Highlights

### Performance improvements

We've migrated Form Builder to leverage the new module loading mechanism introduced in [Core v5](https://github.com/openmrs/openmrs-esm-core/releases/tag/v5.0.0). It now declares its static and dynamic metadata upfront, and the framework uses this information to load only the static bits when the application gets loaded for the first time while loading the dynamic bits is deferred to later when they are needed. This change delivers significant improvements to initial load time. Check out the [migration guide](https://o3-docs.vercel.app/docs/migration-guide) to get a closer look at the internals of the new module loading mechanism.
