### PR TITLE
(fix) Fix styling affecting schema editor dimensions

### DIFF
--- a/src/components/schema-editor/schema-editor.component.tsx
+++ b/src/components/schema-editor/schema-editor.component.tsx
@@ -167,7 +167,7 @@ const SchemaEditor: React.FC<SchemaEditorProps> = ({
       ) : null}
 
       <AceEditor
-        className={styles.editorContainer}
+        style={{ height: "100vh", width: "100%" }}
         mode="json"
         theme="textmate"
         name="schemaEditor"

--- a/src/components/schema-editor/schema-editor.scss
+++ b/src/components/schema-editor/schema-editor.scss
@@ -12,11 +12,6 @@
   }
 }
 
-.editorContainer {
-  height: 100vh;
-  width: 100%;
-}
-
 .errorContainer {
   @include type.type-style("body-compact-02");
   background-color: colors.$red-20;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Fixes an issue with the styling of the schema editor container - making it so that the container spans the full height and width of the viewport. This styling inadvertently got broken in #171.

## Screenshots
*None*
<!-- Required if you are making UI changes. -->

## Related Issue
*None*
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
*None*
<!-- Anything not covered above -->
