### PR TITLE
(feat) Tweak editor action button behaviour

### DIFF
--- a/src/components/schema-editor/schema-editor.component.tsx
+++ b/src/components/schema-editor/schema-editor.component.tsx
@@ -135,26 +135,28 @@ const SchemaEditor: React.FC<SchemaEditorProps> = ({
           />
         ) : null}
 
-        {isNewSchema ? (
+        {isNewSchema && !stringifiedSchema ? (
           <Button kind="secondary" onClick={inputDummySchema}>
             {t("inputDummySchema", "Input dummy schema")}
           </Button>
         ) : null}
 
-        <Button
-          disabled={isRendering}
-          kind="primary"
-          onClick={renderSchemaChanges}
-        >
-          {isRendering ? (
-            <InlineLoading
-              className={styles.spinner}
-              description={t("rendering", "Rendering") + "..."}
-            />
-          ) : (
-            <span>{t("renderChanges", "Render changes")}</span>
-          )}
-        </Button>
+        {schema ? (
+          <Button
+            disabled={isRendering}
+            kind="primary"
+            onClick={renderSchemaChanges}
+          >
+            {isRendering ? (
+              <InlineLoading
+                className={styles.spinner}
+                description={t("render", "Render" + "...")}
+              />
+            ) : (
+              <span>{t("renderChanges", "Render changes")}</span>
+            )}
+          </Button>
+        ) : null}
       </div>
 
       {invalidJsonErrorMessage ? (


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that describes the work done, including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR tweaks the behaviour of action buttons in the form editor so that:

- The `Input dummy schema` button isn't shown when there's a valid schema in the schema editor.
- The `Render changes` button should not get shown if there isn't a valid schema in the schema editor.

## Video

https://github.com/openmrs/openmrs-esm-form-builder/assets/8509731/1ae304e9-d8cd-4214-944d-5d41f4a70c7b
