### PR TITLE
(fix) Always show the `Render changes` button

### DIFF
--- a/src/components/form-editor/form-editor.component.tsx
+++ b/src/components/form-editor/form-editor.component.tsx
@@ -255,11 +255,9 @@ const FormEditor: React.FC = () => {
                 </Button>
               ) : null}
 
-              {schema ? (
-                <Button kind="ghost" onClick={renderSchemaChanges}>
-                  <span>{t("renderChanges", "Render changes")}</span>
-                </Button>
-              ) : null}
+              <Button kind="ghost" onClick={renderSchemaChanges}>
+                <span>{t("renderChanges", "Render changes")}</span>
+              </Button>
             </div>
             <div>
               <span className={styles.tabHeading}>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR removes conditional logic that determines whether or not to show the `Render changes` based on the existence of a valid schema in the schema editor. This currently makes it impossible to render changes when you paste a schema into the schema editor, which happens very often in practice.

