### PR TITLE
(feat) Add copy and download buttons to the schema editor

### DIFF
--- a/src/components/dashboard/dashboard.component.tsx
+++ b/src/components/dashboard/dashboard.component.tsx
@@ -181,7 +181,6 @@ function ActionButtons({
         href={window.URL.createObjectURL(downloadableSchema)}
       >
         <Button
-          className={styles.downloadButton}
           enterDelayMs={300}
           renderIcon={Download}
           kind={"ghost"}

--- a/src/components/form-editor/form-editor.component.tsx
+++ b/src/components/form-editor/form-editor.component.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Button,
   Column,
@@ -16,6 +16,7 @@ import {
   TabPanels,
   TabPanel,
 } from "@carbon/react";
+import { Download, Replicate } from "@carbon/react/icons";
 import { useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { ExtensionSlot } from "@openmrs/esm-framework";
@@ -233,6 +234,18 @@ const FormEditor: React.FC = () => {
     );
   };
 
+  const downloadableSchema = useMemo(
+    () =>
+      new Blob([JSON.stringify(schema, null, 2)], {
+        type: "application/json",
+      }),
+    [schema]
+  );
+
+  const handleCopySchema = useCallback(() => {
+    navigator.clipboard.writeText(stringifiedSchema);
+  }, [stringifiedSchema]);
+
   return (
     <>
       <div className={styles.breadcrumbsContainer}>
@@ -260,9 +273,38 @@ const FormEditor: React.FC = () => {
               </Button>
             </div>
             <div>
-              <span className={styles.tabHeading}>
-                {t("schemaEditor", "Schema Editor")}
-              </span>
+              <div className={styles.heading}>
+                <span className={styles.tabHeading}>
+                  {t("schemaEditor", "Schema Editor")}
+                </span>
+                {schema ? (
+                  <>
+                    <Button
+                      kind="ghost"
+                      size="md"
+                      enterDelayMs={300}
+                      iconDescription={t("copySchema", "Copy schema")}
+                      onClick={handleCopySchema}
+                      renderIcon={(props) => <Replicate size={16} {...props} />}
+                      hasIconOnly
+                    />
+                    <a
+                      download={`${form?.name}.json`}
+                      href={window.URL.createObjectURL(downloadableSchema)}
+                    >
+                      <Button
+                        enterDelayMs={300}
+                        renderIcon={Download}
+                        kind={"ghost"}
+                        iconDescription={t("downloadSchema", "Download schema")}
+                        hasIconOnly
+                        size="md"
+                        tooltipAlignment="start"
+                      />
+                    </a>
+                  </>
+                ) : null}
+              </div>
               {formError ? (
                 <Error
                   error={formError}

--- a/src/components/form-editor/form-editor.scss
+++ b/src/components/form-editor/form-editor.scss
@@ -53,6 +53,12 @@
   padding: 1rem;
 }
 
+.heading {
+  display: flex;
+  margin-right: 1rem;
+  align-items: center;
+}
+
 .tabHeading {
   display: flex;
   align-items: center;

--- a/src/components/interactive-builder/draggable-question.component.tsx
+++ b/src/components/interactive-builder/draggable-question.component.tsx
@@ -63,7 +63,7 @@ export const DraggableQuestion: React.FC<DraggableQuestionProps> = ({
         <Button
           kind="ghost"
           size="sm"
-          enterDelayMs={200}
+          enterDelayMs={300}
           iconDescription={t("duplicateQuestion", "Duplicate question")}
           onClick={() => {
             if (!isDragging) {
@@ -76,7 +76,7 @@ export const DraggableQuestion: React.FC<DraggableQuestionProps> = ({
         <Button
           kind="ghost"
           size="sm"
-          enterDelayMs={200}
+          enterDelayMs={300}
           iconDescription={t("editQuestion", "Edit question")}
           onClick={() => {
             if (!isDragging) {
@@ -88,7 +88,7 @@ export const DraggableQuestion: React.FC<DraggableQuestionProps> = ({
         />
         <Button
           hasIconOnly
-          enterDelayMs={200}
+          enterDelayMs={300}
           iconDescription={t("deleteQuestion", "Delete question")}
           kind="ghost"
           onClick={handleDeleteButtonClick}

--- a/src/components/interactive-builder/editable-value.component.tsx
+++ b/src/components/interactive-builder/editable-value.component.tsx
@@ -45,7 +45,7 @@ const EditableValue: React.FC<EditableValueProps> = ({
       <Button
         kind="ghost"
         size="sm"
-        enterDelayMs={200}
+        enterDelayMs={300}
         iconDescription={t("editButton", "Edit {elementType}", {
           elementType: elementType,
         })}

--- a/src/components/interactive-builder/interactive-builder.component.tsx
+++ b/src/components/interactive-builder/interactive-builder.component.tsx
@@ -471,7 +471,7 @@ const InteractiveBuilder: React.FC<InteractiveBuilderProps> = ({
                   </div>
                   <Button
                     hasIconOnly
-                    enterDelayMs={200}
+                    enterDelayMs={300}
                     iconDescription={t("deletePage", "Delete page")}
                     kind="ghost"
                     onClick={() => {
@@ -511,7 +511,7 @@ const InteractiveBuilder: React.FC<InteractiveBuilderProps> = ({
                               </div>
                               <Button
                                 hasIconOnly
-                                enterDelayMs={200}
+                                enterDelayMs={300}
                                 iconDescription={t(
                                   "deleteSection",
                                   "Delete section"


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR adds two buttons to the schema editor:  a copy button that copies the schema to the clipboard and a download button that downloads it. These two affordances should make it easier for form authors to maintain backups of the most up-to-date versions of their schemas with ease.

## Screenshots

https://github.com/openmrs/openmrs-esm-form-builder/assets/8509731/eeaa18c6-4825-4d5c-8222-b0f759004133
