### PR TITLE
(chore) Update E2E GitHub Action Job Name for Improved Clarity

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  main:
+  run_e2e_tests:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This update changes the job name of the E2E GitHub action to a more meaningful and recognizable name. This will help us easily identify the action in GitHub settings, such as in the branch protection rules page. The change will improve our workflow and make it easier for team members to navigate and manage our GitHub actions.


