### PR TITLE
(fix) Remove unnecessary useEffect

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,7 +20,7 @@
   "rules": {
     // The following rules need `noImplicitAny` to be set to `true` in our tsconfig. They are too restrictive for now, but should be reconsidered in future
     "@typescript-eslint/no-unsafe-assignment": "off",
-    "@typescript-eslint/no-unsafe-call": "off", 
+    "@typescript-eslint/no-unsafe-call": "off",
     "@typescript-eslint/no-unsafe-member-access": "off",
     "@typescript-eslint/unbound-method": "off",
     // Nitpicky. Prefer `interface T` over type T
@@ -41,6 +41,7 @@
         "default": "generic"
       }
     ],
+    "no-console": ["error", { "allow": ["warn", "error"] }],
     "no-restricted-imports": [
       "error",
       {

--- a/src/components/audit-details/audit-details.component.tsx
+++ b/src/components/audit-details/audit-details.component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { formatDatetime, parseDate } from '@openmrs/esm-framework';
 import { StructuredListWrapper, StructuredListRow, StructuredListCell, StructuredListBody } from '@carbon/react';
@@ -37,26 +37,7 @@ interface FormGroupData {
 }
 
 const AuditDetails: React.FC<AuditDetailsProps> = ({ form }) => {
-  console.log('form: ', form);
-
   const { t } = useTranslation();
-  const [description, setDescription] = useState('');
-  const [encounterType, setEncounterType] = useState('');
-  const [name, setName] = useState('');
-  const [published, setPublished] = useState(false);
-  const [retired, setRetired] = useState(false);
-  const [version, setVersion] = useState('');
-
-  useEffect(() => {
-    if (form) {
-      setName(form.name);
-      setDescription(form.description);
-      setEncounterType(`${form.encounterType.display} - ${form.encounterType.uuid}`);
-      setVersion(form.version);
-      setPublished(form.published);
-      setRetired(form.retired);
-    }
-  }, [form]);
 
   return (
     <StructuredListWrapper isCondensed selection={false}>
@@ -65,23 +46,23 @@ const AuditDetails: React.FC<AuditDetailsProps> = ({ form }) => {
           <StructuredListCell>
             <b>{t('formName', 'Form Name')}</b>
           </StructuredListCell>
-          <StructuredListCell>{name}</StructuredListCell>
+          <StructuredListCell>{form.name}</StructuredListCell>
         </StructuredListRow>
         <StructuredListRow>
           <StructuredListCell>{t('description', 'Description')}</StructuredListCell>
-          <StructuredListCell>{description}</StructuredListCell>
+          <StructuredListCell>{form.description}</StructuredListCell>
         </StructuredListRow>
         <StructuredListRow>
           <StructuredListCell>{t('formUuid', 'Form UUID')}</StructuredListCell>
-          <StructuredListCell>{form?.uuid}</StructuredListCell>
+          <StructuredListCell>{form.uuid}</StructuredListCell>
         </StructuredListRow>
         <StructuredListRow>
           <StructuredListCell>{t('version', 'Version')}</StructuredListCell>
-          <StructuredListCell>{version}</StructuredListCell>
+          <StructuredListCell>{form.version}</StructuredListCell>
         </StructuredListRow>
         <StructuredListRow>
           <StructuredListCell>{t('encounterType', 'Encounter Type')}</StructuredListCell>
-          <StructuredListCell>{encounterType}</StructuredListCell>
+          <StructuredListCell>{form.encounterType.uuid}</StructuredListCell>
         </StructuredListRow>
         <StructuredListRow>
           <StructuredListCell>{t('createdBy', 'Created By')}</StructuredListCell>
@@ -101,11 +82,11 @@ const AuditDetails: React.FC<AuditDetailsProps> = ({ form }) => {
         </StructuredListRow>
         <StructuredListRow>
           <StructuredListCell>{t('published', 'Published')}</StructuredListCell>
-          <StructuredListCell>{published ? t('yes', 'Yes') : t('no', 'No')}</StructuredListCell>
+          <StructuredListCell>{form.published ? t('yes', 'Yes') : t('no', 'No')}</StructuredListCell>
         </StructuredListRow>
         <StructuredListRow>
           <StructuredListCell>{t('retired', 'Retired')}</StructuredListCell>
-          <StructuredListCell>{retired ? t('yes', 'Yes') : t('no', 'No')}</StructuredListCell>
+          <StructuredListCell>{form.retired ? t('yes', 'Yes') : t('no', 'No')}</StructuredListCell>
         </StructuredListRow>
       </StructuredListBody>
     </StructuredListWrapper>

--- a/src/components/form-editor/form-editor.component.tsx
+++ b/src/components/form-editor/form-editor.component.tsx
@@ -320,7 +320,7 @@ const FormEditor: React.FC = () => {
                 <TabPanel>
                   <InteractiveBuilder schema={schema} onSchemaChange={updateSchema} isLoading={isLoadingFormOrSchema} />
                 </TabPanel>
-                <TabPanel>{form && <AuditDetails form={form} />}</TabPanel>
+                <TabPanel>{form && <AuditDetails form={form} key={form.uuid} />}</TabPanel>
               </TabPanels>
             </Tabs>
           </Column>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR refactors the AuditDetails component, [getting rid of an unnecessary useEffect](https://react.dev/learn/you-might-not-need-an-effect#resetting-all-state-when-a-prop-changes) and replacing it with a [key](https://react.dev/learn/you-might-not-need-an-effect#resetting-all-state-when-a-prop-changes) so that whenever the key (which I've set to the form UUID) changes, React will recreate the DOM and [reset the state](https://react.dev/learn/preserving-and-resetting-state#option-2-resetting-state-with-a-key) of the `AuditDetails`.

I've also removed a forgotten `console.log` statement and updated our eslint config with a rule that should flag uses of `console.log` in our codebase.

## Screenshots

> Functionality remains unchanged

https://github.com/openmrs/openmrs-esm-form-builder/assets/8509731/c38df294-ae6c-4e30-82d0-a2823663331a

## Related Issue
*None*

## Other
*None*