### PR TITLE
 (BREAKING) Update i18next interpolation syntax

### DIFF
--- a/src/components/interactive-builder/editable-value.component.tsx
+++ b/src/components/interactive-builder/editable-value.component.tsx
@@ -41,7 +41,7 @@ const EditableValue: React.FC<EditableValueProps> = ({ elementType, id, value, o
         kind="ghost"
         size="sm"
         enterDelayMs={300}
-        iconDescription={t('editButton', 'Edit {elementType}', {
+        iconDescription={t('editButton', 'Edit {{elementType}}', {
           elementType: elementType,
         })}
         onClick={() => setEditing(true)}

--- a/translations/am.json
+++ b/translations/am.json
@@ -41,7 +41,7 @@
   "downloadSchema": "Download schema",
   "duplicated": "Duplicated",
   "duplicateQuestion": "Duplicate question",
-  "editButton": "Edit {elementType}",
+  "editButton": "Edit {{elementType}}",
   "editQuestion": "Edit question",
   "editSchema": "Edit schema",
   "encounterType": "Encounter Type",

--- a/translations/en.json
+++ b/translations/en.json
@@ -41,7 +41,7 @@
   "downloadSchema": "Download schema",
   "duplicated": "Duplicated",
   "duplicateQuestion": "Duplicate question",
-  "editButton": "Edit {elementType}",
+  "editButton": "Edit {{elementType}}",
   "editQuestion": "Edit question",
   "editSchema": "Edit schema",
   "encounterType": "Encounter Type",

--- a/translations/es.json
+++ b/translations/es.json
@@ -41,7 +41,7 @@
   "downloadSchema": "Download schema",
   "duplicated": "Duplicated",
   "duplicateQuestion": "Duplicate question",
-  "editButton": "Edit {elementType}",
+  "editButton": "Edit {{elementType}}",
   "editQuestion": "Edit question",
   "editSchema": "Edit schema",
   "encounterType": "Encounter Type",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -41,7 +41,7 @@
   "downloadSchema": "Download schema",
   "duplicated": "Duplicated",
   "duplicateQuestion": "Duplicate question",
-  "editButton": "Edit {elementType}",
+  "editButton": "Edit {{elementType}}",
   "editQuestion": "Edit question",
   "editSchema": "Edit schema",
   "encounterType": "Encounter Type",

--- a/translations/he.json
+++ b/translations/he.json
@@ -41,7 +41,7 @@
   "downloadSchema": "Download schema",
   "duplicated": "Duplicated",
   "duplicateQuestion": "Duplicate question",
-  "editButton": "Edit {elementType}",
+  "editButton": "Edit {{elementType}}",
   "editQuestion": "Edit question",
   "editSchema": "Edit schema",
   "encounterType": "Encounter Type",

--- a/translations/km.json
+++ b/translations/km.json
@@ -41,7 +41,7 @@
   "downloadSchema": "Download schema",
   "duplicated": "Duplicated",
   "duplicateQuestion": "Duplicate question",
-  "editButton": "Edit {elementType}",
+  "editButton": "Edit {{elementType}}",
   "editQuestion": "Edit question",
   "editSchema": "Edit schema",
   "encounterType": "Encounter Type",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary
This PR is a child PR of https://github.com/openmrs/openmrs-esm-core/pull/799.

Notable changes in translations:
1. All the variables should be wrapped in `{{` and `}}` instead of `{` and `}`.
2. Use `count` variable to leverage the pluralization support.

## Screenshots
None

## Related Issue
None

## Other
None