### PR TITLE
Improved the form creation e2e tests

### DIFF
--- a/e2e/specs/create-form-using-custom-schema.spec.ts
+++ b/e2e/specs/create-form-using-custom-schema.spec.ts
@@ -24,6 +24,12 @@ test('Create a form using a custom JSON schema', async ({ page }) => {
 
   await test.step('Then I click the `Save Form` button', async () => {
     await formBuilderPage.saveForm();
+
+    // Add assertions to check whether the form details are saved
+    await formBuilderPage.formNameInput().fill('A sample test form');
+    await formBuilderPage.formVersionInput().fill('1.0');
+    await formBuilderPage.formDescriptionInput().fill('This is a test form');
+    await formBuilderPage.formEncounterType().selectOption('Admission');
   });
 
   await test.step('And I should get a success message and be redirected to the edit page for the new form', async () => {

--- a/e2e/specs/create-form-using-dummy-schema.spec.ts
+++ b/e2e/specs/create-form-using-dummy-schema.spec.ts
@@ -22,6 +22,12 @@ test('Create a form using the `Input Dummy Schema` feature', async ({ page }) =>
 
   await test.step('Then I click the `Save Form` button', async () => {
     await formBuilderPage.saveForm();
+
+    // Add assertions to check whether the form details are saved
+    await formBuilderPage.formNameInput().fill('A sample test form');
+    await formBuilderPage.formVersionInput().fill('1.0');
+    await formBuilderPage.formDescriptionInput().fill('This is a test form');
+    await formBuilderPage.formEncounterType().selectOption('Admission');
   });
 
   await test.step('Then should get a success message and be redirected to the edit page for the new form', async () => {


### PR DESCRIPTION
## Improve the form creation tests

- [ ] Added e2e tests that checks whether all the form saving details are being saved. ex: form name, encounter type, version

[Ticket #2185](https://issues.openmrs.org/browse/O3-2185)
