### PR TITLE
(chore) Set fixStyle for consisent-type-imports eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -30,8 +30,7 @@
     "@typescript-eslint/consistent-type-imports": [
       "error",
       {
-        "prefer": "type-imports",
-        "disallowTypeAnnotations": true
+        "fixStyle": "inline-type-imports"
       }
     ],
     // Use Array<T> instead of T[] consistently


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Tweaks the @typescript/eslint [consistent-type-imports](https://typescript-eslint.io/blog/consistent-type-imports-and-exports-why-and-how) rule so that the [fixStyle](https://typescript-eslint.io/rules/consistent-type-imports/#fixstyle) option defaults to inline-type-imports, which means eslint automatically adds the `type` keyword within the import.

## Screenshots
*None*

## Related Issue
*None*

## Other
*None*
