### PR TITLE
(refactor) Minimal refactors to dashboard page tests

### DIFF
--- a/src/components/header/illo.component.tsx
+++ b/src/components/header/illo.component.tsx
@@ -8,7 +8,7 @@ const Illustration: React.FC = () => {
       viewBox="0 0 32 32"
       xmlns="http://www.w3.org/2000/svg"
       xmlSpace="preserve"
-      fill-rule="evenodd"
+      fillRule="evenodd"
       clipRule="evenodd"
       strokeLinejoin="round"
       strokeMiterlimit="2"


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR applies some minimal refactors to the Dashboard component test suite. These include:

- Removing unnecessary uses of the async `waitFor` function.
- Annotating mock functions with the correct types.

## Screenshots
*None*

## Related Issue
*None*

## Other
*None*