### PR TITLE
(fix) Show Audit Details tab only for existing form schemas

### DIFF
--- a/src/components/form-editor/form-editor.component.tsx
+++ b/src/components/form-editor/form-editor.component.tsx
@@ -315,7 +315,7 @@ const FormEditor: React.FC = () => {
               <TabList aria-label="Form previews">
                 <Tab>{t('preview', 'Preview')}</Tab>
                 <Tab>{t('interactiveBuilder', 'Interactive Builder')}</Tab>
-                {<Tab>{form && t('auditDetails', 'Audit Details')}</Tab>}
+                {form && <Tab>{t('auditDetails', 'Audit Details')}</Tab>}
               </TabList>
               <TabPanels>
                 <TabPanel>

--- a/src/form-builder-admin-card-link.component.tsx
+++ b/src/form-builder-admin-card-link.component.tsx
@@ -11,7 +11,7 @@ const FormBuilderCardLink: React.FC = () => {
       <ClickableTile href={`${window.spaBase}/form-builder`} target="_blank" rel="noopener noreferrer">
         <div>
           <div className="heading">{header}</div>
-          <div className="content">{t('formBuilder', 'Form Builder')}</div>
+          <div className="content">{t('formBuilder', 'Form builder')}</div>
         </div>
         <div className="iconWrapper">
           <ArrowRight size={16} />


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

When creating a new form in the schema editor, an empty tab is currently rendered. This occurs due to the misplacement of the conditional check that controls the rendering of the 'Audit Details' tab.

This PR addresses the issue by relocating the conditional check to its correct position. Now, the 'Audit Details' tab will only render when a form schema already exists, which aligns with the intended behavior.

Unrelated: I've also fixed the translation string for the `formBuilder` key.	

## Screenshots

> Empty tab getting rendered

![CleanShot 2024-01-02 at 2  17 21@2x](https://github.com/openmrs/openmrs-esm-form-builder/assets/8509731/c826f2f4-8886-45b0-a9b2-efcb4d3e1e40)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
