### PR TITLE
(fix) Fix textarea dimensions in save form modal

### DIFF
--- a/src/components/modals/save-form-modal.component.tsx
+++ b/src/components/modals/save-form-modal.component.tsx
@@ -320,8 +320,6 @@ const SaveFormModal: React.FC<SaveFormModalProps> = ({ form, schema }) => {
                 <TextArea
                   labelText={t('description', 'Description')}
                   onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => setDescription(event.target.value)}
-                  cols={6}
-                  rows={3}
                   id="description"
                   placeholder={t(
                     'descriptionPlaceholderText',


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR fixes the width of the textarea `description` field in the `Save form to server` modal so it spans the full width of the modal.

## Screenshots

> Before

![CleanShot 2024-01-09 at 4  33 23@2x](https://github.com/openmrs/openmrs-esm-form-builder/assets/8509731/41b2c33e-00b5-4a44-ac61-2c625323188f)

> After

![CleanShot 2024-01-09 at 4  30 44@2x](https://github.com/openmrs/openmrs-esm-form-builder/assets/8509731/9cd6b7b7-87a2-402d-85c3-7c47cdadb350)

## Related Issue
*None*

## Other
*None*
