### PR TITLE
(feat) Set a 5s timeout on success snackbar notifications

### DIFF
--- a/src/components/action-buttons/action-buttons.component.tsx
+++ b/src/components/action-buttons/action-buttons.component.tsx
@@ -37,6 +37,7 @@ function ActionButtons({ schema, t }: ActionButtonsProps) {
         kind: 'success',
         isLowContrast: true,
         subtitle: `${form.name} ` + t('formPublishedSuccessfully', 'form was published successfully'),
+        timeoutInMs: 5000,
       });
 
       setStatus('published');
@@ -64,6 +65,7 @@ function ActionButtons({ schema, t }: ActionButtonsProps) {
         kind: 'success',
         isLowContrast: true,
         subtitle: `${form.name} ` + t('formUnpublishedSuccessfully', 'form was unpublished successfully'),
+        timeoutInMs: 5000,
       });
 
       setStatus('unpublished');

--- a/src/components/dashboard/dashboard.component.tsx
+++ b/src/components/dashboard/dashboard.component.tsx
@@ -112,6 +112,7 @@ function ActionButtons({ form, mutate, responsiveSize, t }: ActionButtonsProps) 
               kind: 'success',
               isLowContrast: true,
               subtitle: `${form.name} ` + t('formDeletedSuccessfully', 'deleted successfully'),
+              timeoutInMs: 5000,
             });
 
             await mutate();

--- a/src/components/interactive-builder/add-question-modal.component.tsx
+++ b/src/components/interactive-builder/add-question-modal.component.tsx
@@ -167,6 +167,7 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
         kind: 'success',
         isLowContrast: true,
         subtitle: t('questionCreated', 'New question created'),
+        timeoutInMs: 5000,
       });
     } catch (error) {
       if (error instanceof Error) {

--- a/src/components/interactive-builder/delete-page-modal.component.tsx
+++ b/src/components/interactive-builder/delete-page-modal.component.tsx
@@ -35,6 +35,7 @@ const DeletePageModal: React.FC<DeletePageModalProps> = ({
         kind: 'success',
         isLowContrast: true,
         subtitle: t('pageDeleted', 'Page deleted'),
+        timeoutInMs: 5000,
       });
     } catch (error) {
       if (error instanceof Error) {

--- a/src/components/interactive-builder/delete-question-modal.component.tsx
+++ b/src/components/interactive-builder/delete-question-modal.component.tsx
@@ -39,6 +39,7 @@ const DeleteQuestionModal: React.FC<DeleteQuestionModal> = ({
         kind: 'success',
         isLowContrast: true,
         subtitle: t('QuestionDeleted', 'Question deleted'),
+        timeoutInMs: 5000,
       });
     } catch (error) {
       if (error instanceof Error) {

--- a/src/components/interactive-builder/delete-section-modal.component.tsx
+++ b/src/components/interactive-builder/delete-section-modal.component.tsx
@@ -37,6 +37,7 @@ const DeleteSectionModal: React.FC<DeleteSectionModal> = ({
         kind: 'success',
         isLowContrast: true,
         subtitle: t('SectionDeleted', 'Section deleted'),
+        timeoutInMs: 5000,
       });
     } catch (error) {
       if (error instanceof Error) {

--- a/src/components/interactive-builder/edit-question-modal.component.tsx
+++ b/src/components/interactive-builder/edit-question-modal.component.tsx
@@ -214,6 +214,7 @@ const EditQuestionModal: React.FC<EditQuestionModalProps> = ({
         kind: 'success',
         isLowContrast: true,
         subtitle: t('questionUpdated', 'Question updated'),
+        timeoutInMs: 5000,
       });
 
       onModalChange(false);

--- a/src/components/interactive-builder/interactive-builder.component.tsx
+++ b/src/components/interactive-builder/interactive-builder.component.tsx
@@ -110,6 +110,7 @@ const InteractiveBuilder: React.FC<InteractiveBuilderProps> = ({ isLoading, onSc
           kind: 'success',
           isLowContrast: true,
           subtitle: t('formRenamed', 'Form renamed'),
+          timeoutInMs: 5000,
         });
       } catch (error) {
         showSnackbar({
@@ -136,6 +137,7 @@ const InteractiveBuilder: React.FC<InteractiveBuilderProps> = ({ isLoading, onSc
           kind: 'success',
           isLowContrast: true,
           subtitle: t('pageRenamed', 'Page renamed'),
+          timeoutInMs: 5000,
         });
       } catch (error) {
         if (error instanceof Error) {
@@ -165,6 +167,7 @@ const InteractiveBuilder: React.FC<InteractiveBuilderProps> = ({ isLoading, onSc
           kind: 'success',
           isLowContrast: true,
           subtitle: t('sectionRenamed', 'Section renamed'),
+          timeoutInMs: 5000,
         });
       } catch (error) {
         if (error instanceof Error) {
@@ -198,6 +201,7 @@ const InteractiveBuilder: React.FC<InteractiveBuilderProps> = ({ isLoading, onSc
             'questionDuplicated',
             "Question duplicated. Please change the duplicated question's ID to a unique, camelcased value",
           ),
+          timeoutInMs: 5000,
         });
       } catch (error) {
         if (error instanceof Error) {

--- a/src/components/interactive-builder/new-form-modal.component.tsx
+++ b/src/components/interactive-builder/new-form-modal.component.tsx
@@ -36,6 +36,7 @@ const NewFormModal: React.FC<NewFormModalProps> = ({ schema, onSchemaChange, sho
         kind: 'success',
         isLowContrast: true,
         subtitle: t('formCreated', 'New form created'),
+        timeoutInMs: 5000,
       });
     } catch (error) {
       if (error instanceof Error) {

--- a/src/components/interactive-builder/page-modal.component.tsx
+++ b/src/components/interactive-builder/page-modal.component.tsx
@@ -36,6 +36,7 @@ const PageModal: React.FC<PageModalProps> = ({ schema, onSchemaChange, showModal
         kind: 'success',
         isLowContrast: true,
         subtitle: t('pageCreated', 'New page created'),
+        timeoutInMs: 5000,
       });
     } catch (error) {
       if (error instanceof Error) {

--- a/src/components/interactive-builder/section-modal.component.tsx
+++ b/src/components/interactive-builder/section-modal.component.tsx
@@ -45,6 +45,7 @@ const SectionModal: React.FC<SectionModalProps> = ({
         kind: 'success',
         isLowContrast: true,
         subtitle: t('sectionCreated', 'New section created'),
+        timeoutInMs: 5000,
       });
     } catch (error) {
       if (error instanceof Error) {

--- a/src/components/modals/save-form-modal.component.tsx
+++ b/src/components/modals/save-form-modal.component.tsx
@@ -132,6 +132,7 @@ const SaveFormModal: React.FC<SaveFormModalProps> = ({ form, schema }) => {
           isLowContrast: true,
           subtitle:
             name + ' ' + t('saveSuccessMessage', 'was created successfully. It is now visible on the Forms dashboard.'),
+          timeoutInMs: 5000,
         });
         clearDraftFormSchema();
         setOpenSaveFormModal(false);
@@ -184,6 +185,7 @@ const SaveFormModal: React.FC<SaveFormModalProps> = ({ form, schema }) => {
                             kind: 'success',
                             isLowContrast: true,
                             subtitle: form?.name + ' ' + t('saveSuccess', 'was updated successfully'),
+                            timeoutInMs: 5000,
                           });
                           setOpenSaveFormModal(false);
                           await mutate();


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR adds an automatic 5 second timeout for success notifications in the Form Builder. During the process of building out a form schema, several success notifications get shown for actions such as creating a form, adding a page, adding a question, and so on. Having multiple notifications rendered on the same page doesn't offer the greatest UX, hence the rationale for this change.

## Screenshots

https://github.com/openmrs/openmrs-esm-form-builder/assets/8509731/07b2f017-7119-4d61-93ee-4aa061959cd0

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
