### PR TITLE
(feat) Preload form schemas on hover

### DIFF
--- a/src/components/dashboard/dashboard.component.tsx
+++ b/src/components/dashboard/dashboard.component.tsx
@@ -37,8 +37,9 @@ import {
   useLayoutType,
   usePagination,
   useDebounce,
+  openmrsFetch,
 } from '@openmrs/esm-framework';
-import type { KeyedMutator } from 'swr';
+import { type KeyedMutator, preload } from 'swr';
 
 import type { Form as TypedForm } from '../../types';
 import { deleteForm } from '../../forms.resource';
@@ -306,6 +307,7 @@ function FormsList({ forms, isValidating, mutate, t }: FormsListProps) {
     },
   ];
 
+  const editSchemaUrl = '${openmrsSpaBase}/form-builder/edit/${formUuid}';
   const { paginated, goTo, results, currentPage } = usePagination(filteredForms, pageSize);
 
   const tableRows = results?.map((form: TypedForm) => ({
@@ -314,7 +316,9 @@ function FormsList({ forms, isValidating, mutate, t }: FormsListProps) {
     name: (
       <ConfigurableLink
         className={styles.link}
-        to={`${window.getOpenmrsSpaBase() + `form-builder/edit/` + form?.uuid}`}
+        to={editSchemaUrl}
+        templateParams={{ formUuid: form?.uuid }}
+        onMouseEnter={() => void preload(`/ws/rest/v1/form/${form?.uuid}?v=full`, openmrsFetch)}
       >
         {form.name}
       </ConfigurableLink>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

SWR's [preload API](https://swr.vercel.app/docs/prefetching#programmatically-prefetch) makes it possible to prefetch resources programmatically and store the results in the cache. I've leveraged this ability so that when the user hovers over a link to a schema in the forms dashboard table, a request gets fired off to the backend. This means that when the user does click on the link, the schema loads up immediately without showing a loading spinner. 

An unrelated change I've made here involves cleaning up the ConfigurableLink implementation to leverage interpolation. Functionality is unchanged.

## Screenshots

### Before

https://github.com/openmrs/openmrs-esm-form-builder/assets/8509731/847bdf04-5bd9-41d8-85f8-a29244d7adda

### After

https://github.com/openmrs/openmrs-esm-form-builder/assets/8509731/b5d6435f-07e1-40fc-bf43-5a435dc50ce9

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
