### PR TITLE
(chore) Switch to new frontend build job in CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -104,6 +104,21 @@ jobs:
           path: |
             dist
 
+  deploy_form_builder:
+    runs-on: ubuntu-latest
+
+    needs: pre_release
+
+    if: ${{ github.event_name == 'push' }}
+
+    steps:
+      - name: Trigger RefApp Build
+        uses: fjogeleit/http-request-action@master
+        with:
+          url: https://ci.openmrs.org/rest/api/latest/queue/O3-BF
+          method: "POST"
+          customHeaders: '{ "Authorization": "Bearer ${{ secrets.BAMBOO_TOKEN }}" }'
+
   release:
     runs-on: ubuntu-latest
 
@@ -145,18 +160,3 @@ jobs:
           path: |
             dist
 
-  deploy_form_builder:
-      runs-on: ubuntu-latest
-
-      needs: pre_release
-
-      if: ${{ github.event_name == 'push' }}
-
-      steps:
-        - name: Trigger RefApp Build
-          uses: fjogeleit/http-request-action@master
-          continue-on-error: true
-          with:
-            url: https://ci.openmrs.org/rest/api/latest/queue/REFAPP-D3X
-            method: "POST"
-            customHeaders: '{ "Authorization": "Bearer ${{ secrets.BAMBOO_TOKEN }}" }'


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Switches the deploy job in the Form Builder's CI to use the new Bamboo frontend [build job](https://ci.openmrs.org/browse/O3-BF). Builds are currently referencing the old REFAPP-D3X job, which was turned off in favour of the new O3-BF job.

## Screenshots

### Builds are silently failing to deploy with this error:

![CleanShot 2024-02-08 at 12  38 07@2x](https://github.com/openmrs/openmrs-esm-form-builder/assets/8509731/797de157-adc6-467b-a714-09b64f403008)


## Related Issue
*None*

## Other
*None*

