### PR TITLE
(refactor) Replace usages of `/ws/rest/v1/` with restBaseUrl

### DIFF
--- a/src/components/dashboard/dashboard.component.tsx
+++ b/src/components/dashboard/dashboard.component.tsx
@@ -38,6 +38,7 @@ import {
   usePagination,
   useDebounce,
   openmrsFetch,
+  restBaseUrl,
 } from '@openmrs/esm-framework';
 import { type KeyedMutator, preload } from 'swr';
 
@@ -318,7 +319,7 @@ function FormsList({ forms, isValidating, mutate, t }: FormsListProps) {
         className={styles.link}
         to={editSchemaUrl}
         templateParams={{ formUuid: form?.uuid }}
-        onMouseEnter={() => void preload(`/ws/rest/v1/form/${form?.uuid}?v=full`, openmrsFetch)}
+        onMouseEnter={() => void preload(`${restBaseUrl}/form/${form?.uuid}?v=full`, openmrsFetch)}
       >
         {form.name}
       </ConfigurableLink>

--- a/src/forms.resource.ts
+++ b/src/forms.resource.ts
@@ -1,4 +1,4 @@
-import { openmrsFetch, type FetchResponse } from '@openmrs/esm-framework';
+import { openmrsFetch, type FetchResponse, restBaseUrl } from '@openmrs/esm-framework';
 import type { Form, Schema } from './types';
 
 interface SavePayload {
@@ -10,7 +10,7 @@ interface SavePayload {
 }
 
 export async function deleteClobdata(valueReference: string): Promise<FetchResponse<Schema>> {
-  const response: FetchResponse = await openmrsFetch(`/ws/rest/v1/clobdata/${valueReference}`, {
+  const response: FetchResponse = await openmrsFetch(`${restBaseUrl}/clobdata/${valueReference}`, {
     method: 'DELETE',
     headers: { 'Content-Type': 'application/json' },
   });
@@ -18,7 +18,7 @@ export async function deleteClobdata(valueReference: string): Promise<FetchRespo
 }
 
 export async function deleteForm(formUuid: string): Promise<FetchResponse<Record<string, never>>> {
-  const response: FetchResponse = await openmrsFetch(`/ws/rest/v1/form/${formUuid}`, {
+  const response: FetchResponse = await openmrsFetch(`${restBaseUrl}/form/${formUuid}`, {
     method: 'DELETE',
     headers: { 'Content-Type': 'application/json' },
   });
@@ -29,7 +29,7 @@ export async function deleteResource(
   formUuid: string,
   resourceUuid: string,
 ): Promise<FetchResponse<Record<string, never>>> {
-  const response: FetchResponse = await openmrsFetch(`/ws/rest/v1/form/${formUuid}/resource/${resourceUuid}`, {
+  const response: FetchResponse = await openmrsFetch(`${restBaseUrl}/form/${formUuid}/resource/${resourceUuid}`, {
     method: 'DELETE',
     headers: { 'Content-Type': 'application/json' },
   });
@@ -44,7 +44,7 @@ export async function uploadSchema(schema: Schema): Promise<string> {
   body.append('file', schemaBlob);
 
   const response = await window
-    .fetch(`${window.openmrsBase}/ws/rest/v1/clobdata`, {
+    .fetch(`${window.openmrsBase}/${restBaseUrl}/clobdata`, {
       body,
       method: 'POST',
     })
@@ -62,7 +62,7 @@ export async function getResourceUuid(formUuid: string, valueReference: string):
     valueReference: valueReference,
   };
 
-  const response: FetchResponse = await openmrsFetch(`/ws/rest/v1/form/${formUuid}/resource`, {
+  const response: FetchResponse = await openmrsFetch(`${restBaseUrl}/form/${formUuid}/resource`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: body,
@@ -88,7 +88,7 @@ export async function updateForm(
     },
   };
 
-  const response: FetchResponse = await openmrsFetch(`/ws/rest/v1/form/${formUuid}`, {
+  const response: FetchResponse = await openmrsFetch(`${restBaseUrl}/form/${formUuid}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: body,
@@ -121,7 +121,7 @@ export async function saveNewForm(
     'Content-Type': 'application/json',
   };
 
-  const response: FetchResponse<Form> = await openmrsFetch(`/ws/rest/v1/form`, {
+  const response: FetchResponse<Form> = await openmrsFetch(`${restBaseUrl}/form`, {
     method: 'POST',
     headers: headers,
     body: body,
@@ -133,7 +133,7 @@ export async function saveNewForm(
 
 export async function publishForm(uuid: string): Promise<FetchResponse<Form>> {
   const body = { published: true };
-  const response: FetchResponse = await openmrsFetch(`/ws/rest/v1/form/${uuid}`, {
+  const response: FetchResponse = await openmrsFetch(`${restBaseUrl}/form/${uuid}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: body,
@@ -143,7 +143,7 @@ export async function publishForm(uuid: string): Promise<FetchResponse<Form>> {
 
 export async function unpublishForm(uuid: string): Promise<FetchResponse<Form>> {
   const body = { published: false };
-  const response: FetchResponse = await openmrsFetch(`/ws/rest/v1/form/${uuid}`, {
+  const response: FetchResponse = await openmrsFetch(`${restBaseUrl}/form/${uuid}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: body,

--- a/src/hooks/useClobdata.ts
+++ b/src/hooks/useClobdata.ts
@@ -1,11 +1,11 @@
 import useSWRImmutable from 'swr/immutable';
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import type { Form, Schema } from '../types';
 
 export const useClobdata = (form?: Form) => {
   const valueReferenceUuid = form?.resources?.find(({ name }) => name === 'JSON schema')?.valueReference;
   const formHasResources = form && form?.resources?.length > 0 && valueReferenceUuid;
-  const url = `/ws/rest/v1/clobdata/${valueReferenceUuid}`;
+  const url = `${restBaseUrl}/clobdata/${valueReferenceUuid}`;
 
   const { data, error, isLoading, isValidating, mutate } = useSWRImmutable<{ data: Schema }, Error>(
     formHasResources ? url : null,

--- a/src/hooks/useConceptLookup.ts
+++ b/src/hooks/useConceptLookup.ts
@@ -1,9 +1,9 @@
 import useSWR from 'swr';
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import type { Concept } from '../types';
 
 export function useConceptLookup(conceptId: string) {
-  const url = `/ws/rest/v1/concept?q=${conceptId}&v=full`;
+  const url = `${restBaseUrl}/concept?q=${conceptId}&v=full`;
 
   const { data, error } = useSWR<{ data: { results: Array<Concept> } }, Error>(conceptId ? url : null, openmrsFetch);
 

--- a/src/hooks/useConceptName.ts
+++ b/src/hooks/useConceptName.ts
@@ -1,9 +1,9 @@
 import useSWR from 'swr';
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 
 export function useConceptName(conceptId: string | undefined) {
   const customRepresentation = 'custom:(name:(display))';
-  const url = `/ws/rest/v1/concept/${conceptId}?v=${customRepresentation}`;
+  const url = `${restBaseUrl}/concept/${conceptId}?v=${customRepresentation}`;
 
   const { data, error } = useSWR<{ data: { name: { display: string } } }, Error>(conceptId ? url : null, openmrsFetch);
 

--- a/src/hooks/useEncounterTypes.ts
+++ b/src/hooks/useEncounterTypes.ts
@@ -1,9 +1,9 @@
 import useSWRImmutable from 'swr/immutable';
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import type { EncounterType } from '../types';
 
 export const useEncounterTypes = () => {
-  const url = `/ws/rest/v1/encountertype?v=custom:(uuid,name)`;
+  const url = `${restBaseUrl}/encountertype?v=custom:(uuid,name)`;
 
   const { data, error, isLoading } = useSWRImmutable<{ data: { results: Array<EncounterType> } }, Error>(
     url,

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -3,7 +3,7 @@ import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import type { Form } from '../types';
 
 export const useForm = (uuid: string) => {
-  const url = `${restBaseUrl}/${uuid}?v=full`;
+  const url = `${restBaseUrl}/form/${uuid}?v=full`;
 
   const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: Form }, Error>(
     uuid ? url : null,

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -1,9 +1,9 @@
 import useSWR from 'swr/immutable';
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import type { Form } from '../types';
 
 export const useForm = (uuid: string) => {
-  const url = `/ws/rest/v1/form/${uuid}?v=full`;
+  const url = `${restBaseUrl}/${uuid}?v=full`;
 
   const { data, error, isLoading, isValidating, mutate } = useSWR<{ data: Form }, Error>(
     uuid ? url : null,

--- a/src/hooks/useForms.ts
+++ b/src/hooks/useForms.ts
@@ -1,10 +1,9 @@
 import useSWR from 'swr';
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import type { Form } from '../types';
 
 export function useForms() {
-  const url =
-    '/ws/rest/v1/form?v=custom:(uuid,name,encounterType:(uuid,name),version,published,retired,resources:(uuid,name,dataType,valueReference))';
+  const url = `${restBaseUrl}/form?v=custom:(uuid,name,encounterType:(uuid,name),version,published,retired,resources:(uuid,name,dataType,valueReference))`;
 
   const { data, error, isValidating, mutate } = useSWR<{ data: { results: Array<Form> } }, Error>(url, openmrsFetch);
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Change all instances of the hard-coded API base URL '/ws/rest/v1/' to use the restBaseUrl variable instead. To enhances maintainability and flexibility of the API base URL configuration.

## Screenshots
Not available
## Related Issue

https://openmrs.atlassian.net/browse/O3-2815
## Other
<!-- Anything not covered above -->
