### PR TITLE
(chore) Add Eslint Rule to validate exhaustive deps rule on React hooks

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,9 +15,10 @@
     "project": true,
     "tsconfigRootDir": "__dirname"
   },
-  "plugins": ["@typescript-eslint"],
+  "plugins": ["@typescript-eslint", "react-hooks"],
   "root": true,
   "rules": {
+    "react-hooks/exhaustive-deps": "warn",
     // The following rules need `noImplicitAny` to be set to `true` in our tsconfig. They are too restrictive for now, but should be reconsidered in future
     "@typescript-eslint/no-unsafe-assignment": "off",
     "@typescript-eslint/no-unsafe-call": "off",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "eslint-config-ts-react-important-stuff": "^3.0.0",
     "eslint-plugin-playwright": "^0.16.0",
     "eslint-plugin-prettier": "^5.0.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "husky": "^8.0.3",
     "i18next": "^23.5.1",
     "i18next-parser": "^8.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3271,6 +3271,7 @@ __metadata:
     eslint-config-ts-react-important-stuff: "npm:^3.0.0"
     eslint-plugin-playwright: "npm:^0.16.0"
     eslint-plugin-prettier: "npm:^5.0.0"
+    eslint-plugin-react-hooks: "npm:^4.6.0"
     file-loader: "npm:^6.2.0"
     fuzzy: "npm:^0.1.3"
     husky: "npm:^8.0.3"
@@ -9391,7 +9392,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-hooks@npm:^4.0.8":
+"eslint-plugin-react-hooks@npm:^4.0.8, eslint-plugin-react-hooks@npm:^4.6.0":
   version: 4.6.0
   resolution: "eslint-plugin-react-hooks@npm:4.6.0"
   peerDependencies:


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
- This adds a rule to our eslint to validate exhaustive dependencies for a `react-hook`

## Screenshots
<img width="1118" alt="Screenshot 2024-04-03 at 13 59 34" src="https://github.com/openmrs/openmrs-esm-form-builder/assets/30952856/15c003ab-8418-4827-badc-02783e9acf35">


## Related Issue
https://openmrs.atlassian.net/browse/O3-3028

