### PR TITLE
(feat) O3-2972: Validate number fields whose concepts don't allow decimal values

### DIFF
--- a/src/components/interactive-builder/add-question-modal.component.tsx
+++ b/src/components/interactive-builder/add-question-modal.component.tsx
@@ -184,6 +184,9 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
             })),
           }),
           ...(questionType === 'personAttribute' && { attributeType: selectedPersonAttributeType.uuid }),
+          ...(questionType === 'obs' &&
+            renderingType === 'number' &&
+            selectedConcept?.allowDecimal === false && { disallowDecimals: true }),
         },
         validators: [],
       };
@@ -480,6 +483,14 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
                         );
                       })()}
                     </div>
+                  )}
+
+                  {selectedConcept?.allowDecimal === false && (
+                    <InlineNotification
+                      kind="info"
+                      lowContrast
+                      title={t('decimalsNotAllowed', 'This concept does not allow decimals')}
+                    />
                   )}
 
                   {conceptMappings?.length ? (

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,6 +137,7 @@ export interface Concept {
   display: string;
   mappings: Array<Mapping>;
   answers: Array<ConceptAnswer>;
+  allowDecimal?: boolean;
 }
 
 export interface ConceptAnswer {

--- a/translations/en.json
+++ b/translations/en.json
@@ -28,6 +28,7 @@
   "createNewQuestion": "Create a new question",
   "createNewSection": "Create a new section",
   "datePickerType": "The type of date picker to show ",
+  "decimalsNotAllowed": "This concept does not allow decimals",
   "delete": "Delete",
   "deleteForm": "Delete form",
   "deleteFormConfirmation": "Are you sure you want to delete this form?",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR adds a boolean property `disallowDecimals` to a questionOptions definition of `number` values whose backing concepts don't allow decimal values via the interactive builder.

## Video

https://github.com/openmrs/openmrs-esm-form-builder/assets/8509731/e9f76035-ecb0-48ac-83d2-595ecb3f52cb

## Related Issue

[O3-2972)](https://openmrs.atlassian.net/browse/O3-2972)

## Other
<!-- Anything not covered above -->
