### PR TITLE
(feat) O3-3132: Ability to import JSON schemas into the form builder

### DIFF
--- a/src/components/form-editor/form-editor.component.tsx
+++ b/src/components/form-editor/form-editor.component.tsx
@@ -17,6 +17,7 @@ import {
   TabList,
   TabPanels,
   TabPanel,
+  FileUploader,
 } from '@carbon/react';
 import { ArrowLeft, Download, Maximize, Minimize } from '@carbon/react/icons';
 import { useParams } from 'react-router-dom';
@@ -229,6 +230,27 @@ const FormEditor: React.FC = () => {
     );
   };
 
+  const handleSchemaImport = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files[0];
+    const reader = new FileReader();
+
+    reader.onload = (e) => {
+      const result = e.target?.result;
+      if (typeof result === 'string') {
+        const fileContent: string = result;
+        const parsedJson: Schema = JSON.parse(fileContent);
+        setSchema(parsedJson);
+      } else if (result instanceof ArrayBuffer) {
+        const decoder = new TextDecoder();
+        const fileContent: string = decoder.decode(result);
+        const parsedJson: Schema = JSON.parse(fileContent);
+        setSchema(parsedJson);
+      }
+    };
+
+    reader.readAsText(file);
+  };
+
   const downloadableSchema = useMemo(
     () =>
       new Blob([JSON.stringify(schema, null, 2)], {
@@ -265,8 +287,23 @@ const FormEditor: React.FC = () => {
               ) : (
                 <h1 className={styles.formName}>{form?.name}</h1>
               )}
-
-              <div>
+              <div className={styles.topBtns}>
+                {!schema ? (
+                  <FileUploader
+                    onChange={handleSchemaImport}
+                    labelTitle=""
+                    labelDescription=""
+                    buttonLabel={t('importForm', 'Import Form')}
+                    buttonKind="ghost"
+                    size="md"
+                    filenameStatus="edit"
+                    accept={['.json']}
+                    multiple={false}
+                    disabled={false}
+                    iconDescription="Delete file"
+                    name="form-import"
+                  />
+                ) : null}
                 {isNewSchema && !schema ? (
                   <Button kind="ghost" onClick={inputDummySchema}>
                     {t('inputDummySchema', 'Input dummy schema')}

--- a/src/components/form-editor/form-editor.component.tsx
+++ b/src/components/form-editor/form-editor.component.tsx
@@ -295,12 +295,12 @@ const FormEditor: React.FC = () => {
                     labelDescription=""
                     buttonLabel={t('importSchema', 'Import schema')}
                     buttonKind="ghost"
-                    size="md"
+                    size="lg"
                     filenameStatus="edit"
                     accept={['.json']}
                     multiple={false}
                     disabled={false}
-                    iconDescription="Delete file"
+                    iconDescription={t('importSchema', 'Import schema')}
                     name="form-import"
                   />
                 ) : null}

--- a/src/components/form-editor/form-editor.component.tsx
+++ b/src/components/form-editor/form-editor.component.tsx
@@ -293,7 +293,7 @@ const FormEditor: React.FC = () => {
                     onChange={handleSchemaImport}
                     labelTitle=""
                     labelDescription=""
-                    buttonLabel={t('importForm', 'Import Form')}
+                    buttonLabel={t('importSchema', 'Import schema')}
                     buttonKind="ghost"
                     size="md"
                     filenameStatus="edit"

--- a/src/components/form-editor/form-editor.scss
+++ b/src/components/form-editor/form-editor.scss
@@ -97,3 +97,8 @@
 button {
   padding-block-start: 0.5rem;
 }
+
+.topBtns {
+  display: flex;
+  align-items: center;
+}

--- a/translations/en.json
+++ b/translations/en.json
@@ -98,6 +98,7 @@
   "formUuid": "Form UUID",
   "home": "Home",
   "import": "Import",
+  "importForm": "Import Form",
   "inputDummySchema": "Input dummy schema",
   "interactiveBuilder": "Interactive Builder",
   "interactiveBuilderHelperText": "The Interactive Builder lets you build your form schema without writing JSON code. The Preview tab automatically updates as you build your form. When done, click Save Form to save your form.",

--- a/translations/en.json
+++ b/translations/en.json
@@ -98,7 +98,7 @@
   "formUuid": "Form UUID",
   "home": "Home",
   "import": "Import",
-  "importForm": "Import Form",
+  "importSchema": "Import schema",
   "inputDummySchema": "Input dummy schema",
   "interactiveBuilder": "Interactive Builder",
   "interactiveBuilderHelperText": "The Interactive Builder lets you build your form schema without writing JSON code. The Preview tab automatically updates as you build your form. When done, click Save Form to save your form.",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
- This PR adds the ability to import a finished form into o3 instead of copying and pasting.

## Screenshots

https://github.com/openmrs/openmrs-esm-form-builder/assets/30952856/43e673cd-da6f-456e-8804-336a914f8775

## Related Issue
[Ticket](https://openmrs.atlassian.net/browse/O3-3132)

