### PR TITLE
(feat): Add ability for autocompletion in the schema editor.

### DIFF
--- a/src/components/schema-editor/schema-editor.component.tsx
+++ b/src/components/schema-editor/schema-editor.component.tsx
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import AceEditor from 'react-ace';
 import 'ace-builds/webpack-resolver';
 import 'ace-builds/src-noconflict/ext-language_tools';
+import { addCompleter } from 'ace-builds/src-noconflict/ext-language_tools';
 import { useTranslation } from 'react-i18next';
+import { useStandardFormSchema } from '../../hooks/useStandardSchema';
 import styles from './schema-editor.scss';
 
 interface SchemaEditorProps {
@@ -13,7 +15,74 @@ interface SchemaEditorProps {
 }
 
 const SchemaEditor: React.FC<SchemaEditorProps> = ({ invalidJsonErrorMessage, onSchemaChange, stringifiedSchema }) => {
+  const { schema } = useStandardFormSchema();
   const { t } = useTranslation();
+  const [autocompleteSuggestions, setAutocompleteSuggestions] = useState<
+    Array<{ name: string; type: string; path: string }>
+  >([]);
+
+  const generateAutocompleteSuggestions = useCallback(() => {
+    const suggestions: Array<{ name: string; type: string; path: string }> = [];
+
+    const traverseSchema = (schema: unknown, path: string) => {
+      if (schema) {
+        if (schema && typeof schema === 'object') {
+          Object.entries(schema).forEach(([propertyName, property]) => {
+            if (propertyName === '$schema') {
+              return;
+            }
+
+            const currentPath = path ? `${path}.${propertyName}` : propertyName;
+            const typedProperty = property as {
+              type?: string;
+              properties?: Array<{ type: string }>;
+              items?: { type?: string; properties?: Array<{ type: string }> };
+              oneOf?: Array<{ type: string }>;
+            };
+
+            if (typeof property === 'object') {
+              if (typedProperty.type === 'array' && typedProperty.items && typedProperty.items.properties) {
+                traverseSchema(typedProperty.items.properties, currentPath);
+              } else if (typedProperty.properties) {
+                traverseSchema(typedProperty.properties, currentPath);
+              } else if (typedProperty.oneOf) {
+                const types = typedProperty?.oneOf?.map((item: { type: string }) => item.type).join(' | ');
+                suggestions.push({ name: propertyName, type: types || 'any', path: currentPath });
+              }
+            }
+
+            suggestions.push({ name: propertyName, type: typedProperty.type || 'any', path: currentPath });
+          });
+        }
+      }
+    };
+    traverseSchema(schema, '');
+    return suggestions;
+  }, [schema]);
+
+  useEffect(() => {
+    // Generate autocomplete suggestions when schema changes
+    const suggestions = generateAutocompleteSuggestions();
+    setAutocompleteSuggestions(suggestions.flat());
+  }, [schema, generateAutocompleteSuggestions]);
+
+  useEffect(() => {
+    addCompleter({
+      getCompletions: function (editor, session, pos, prefix, callback) {
+        callback(
+          null,
+          autocompleteSuggestions.map(function (word) {
+            return {
+              caption: word.name,
+              value: word.name,
+              meta: word.type,
+              docText: `Path: ${word.path}`,
+            };
+          }),
+        );
+      },
+    });
+  }, [autocompleteSuggestions]);
 
   return (
     <>
@@ -36,8 +105,8 @@ const SchemaEditor: React.FC<SchemaEditorProps> = ({ invalidJsonErrorMessage, on
         highlightActiveLine={true}
         value={stringifiedSchema}
         setOptions={{
-          enableBasicAutocompletion: false,
-          enableLiveAutocompletion: false,
+          enableBasicAutocompletion: true,
+          enableLiveAutocompletion: true,
           displayIndentGuides: true,
           enableSnippets: false,
           showLineNumbers: true,

--- a/src/hooks/useStandardSchema.ts
+++ b/src/hooks/useStandardSchema.ts
@@ -1,0 +1,13 @@
+import useSWRImmutable from 'swr/immutable';
+import { openmrsFetch } from '@openmrs/esm-framework';
+
+export function useStandardFormSchema() {
+  const url = 'https://json.openmrs.org/form.schema.json';
+  const { data, error, isLoading } = useSWRImmutable<{ data }, Error>(url, openmrsFetch);
+
+  return {
+    schema: data?.data.properties,
+    error,
+    isLoading,
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import type { ReferencedForm, RenderType } from '@openmrs/openmrs-form-engine-lib';
 import type { AuditInfo } from './components/audit-details/audit-details.component';
+import type { OpenmrsResource } from '@openmrs/esm-framework';
 
 export interface Form {
   uuid: string;
@@ -58,7 +59,6 @@ export interface Schema {
       questions: Array<{
         id: string;
         label: string;
-        // TODO: This should be a union of all question types i.e QuestionType
         type: string;
         required?: boolean;
         questionOptions: {
@@ -80,6 +80,17 @@ export interface Schema {
   referencedForms: Array<ReferencedForm>;
   version?: string;
   description?: string;
+  encounter?: string | OpenmrsEncounter;
+  allowUnspecifiedAll?: boolean;
+  defaultPage?: string;
+  readonly?: string | boolean;
+  inlineRendering?: 'single-line' | 'multiline' | 'automatic';
+  markdown?: unknown;
+  postSubmissionActions?: Array<{ actionId: string; config?: Record<string, unknown> }>;
+  formOptions?: {
+    usePreviousValueDisabled: boolean;
+  };
+  translations?: Record<string, string>;
 }
 
 export interface SchemaContextType {
@@ -161,4 +172,53 @@ export interface PersonAttributeType {
     display: string;
     answers: Array<ConceptAnswer>;
   };
+}
+
+export interface OpenmrsEncounter {
+  uuid?: string;
+  encounterDatetime?: string | Date;
+  patient?: OpenmrsResource | string;
+  location?: OpenmrsResource | string;
+  encounterType?: OpenmrsResource | string;
+  obs?: Array<OpenmrsObs>;
+  orders?: Array<OpenmrsResource>;
+  voided?: boolean;
+  visit?: OpenmrsResource | string;
+  encounterProviders?: Array<Record<string, unknown>>;
+  form?: {
+    uuid: string;
+    [anythingElse: string]: unknown;
+  };
+}
+
+export type SessionMode = 'edit' | 'enter' | 'view' | 'embedded-view';
+
+export interface PostSubmissionAction {
+  applyAction(
+    formSession: {
+      patient: fhir.Patient;
+      encounters: Array<OpenmrsEncounter>;
+      sessionMode: SessionMode;
+    },
+    config?: Record<string, unknown>,
+    enabled?: string,
+  ): void;
+}
+
+export interface OpenmrsObs extends OpenmrsResource {
+  concept: OpenmrsResource;
+  obsDatetime: string | Date;
+  obsGroup: OpenmrsObs;
+  groupMembers: Array<OpenmrsObs>;
+  comment: string;
+  location: OpenmrsResource;
+  order: OpenmrsResource;
+  encounter: OpenmrsResource;
+  voided: boolean;
+  value: unknown;
+  formFieldPath: string;
+  formFieldNamespace: string;
+  status: string;
+  interpretation: string;
+  [anythingElse: string]: unknown;
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
- This adds the functionality for autocomplete as one types in the schema editor. This is meant to help schema builders know what properties are expected in our form schema, the auto completes indicate the `dataType` for that specific property and the `path` where it should be placed within the schema. Overall, this is a very powerful improvement to our schema and a very helpful feature to ensure that our form users build schemas that conform with the standard schema.

## Screenshots(with path added)
<img width="662" alt="Screenshot 2024-05-03 at 21 48 26" src="https://github.com/openmrs/openmrs-esm-form-builder/assets/30952856/48f4156c-c146-4826-a044-ebc5c9aab4ee">

# recording

https://github.com/openmrs/openmrs-esm-form-builder/assets/30952856/d33ffa35-4039-4e11-8c3c-2c0d4620e205


## Related Issue
- https://openmrs.atlassian.net/browse/O3-3134

