### PR TITLE
(feat) O3-3218: Make the schema validation(block/allow) render a configuration

### DIFF
--- a/src/components/action-buttons/action-buttons.component.tsx
+++ b/src/components/action-buttons/action-buttons.component.tsx
@@ -10,6 +10,7 @@ import { useForm } from '../../hooks/useForm';
 import SaveFormModal from '../modals/save-form-modal.component';
 import { handleFormValidation } from '../../form-validator.resource';
 import styles from './action-buttons.scss';
+import type { IMarker } from 'react-ace';
 
 interface ActionButtonsProps {
   schema: Schema;
@@ -19,6 +20,11 @@ interface ActionButtonsProps {
   setValidationComplete: (validationStatus: boolean) => void;
   setValidationResponse: (errors: Array<unknown>) => void;
   onFormValidation: () => Promise<void>;
+  schemaErrors: Array<MarkerProps>;
+}
+
+interface MarkerProps extends IMarker {
+  text: string;
 }
 
 type Status =
@@ -39,6 +45,7 @@ function ActionButtons({
   onFormValidation,
   setValidationComplete,
   setValidationResponse,
+  schemaErrors,
 }: ActionButtonsProps) {
   const { formUuid } = useParams<{ formUuid?: string }>();
   const { form, mutate } = useForm(formUuid);
@@ -135,7 +142,7 @@ function ActionButtons({
             <Button
               kind="secondary"
               onClick={handleValidateAndPublish}
-              disabled={status === 'validateBeforePublishing'}
+              disabled={status === 'validateBeforePublishing' || schemaErrors.length > 0}
             >
               {status === 'validateBeforePublishing' ? (
                 <InlineLoading className={styles.spinner} description={t('validating', 'Validating') + '...'} />
@@ -144,7 +151,11 @@ function ActionButtons({
               )}
             </Button>
           ) : (
-            <Button kind="secondary" onClick={handlePublish} disabled={status === 'publishing'}>
+            <Button
+              kind="secondary"
+              onClick={handlePublish}
+              disabled={status === 'publishing' || schemaErrors.length > 0}
+            >
               {status === 'publishing' && !form?.published ? (
                 <InlineLoading className={styles.spinner} description={t('publishing', 'Publishing') + '...'} />
               ) : (

--- a/src/components/form-editor/form-editor.component.tsx
+++ b/src/components/form-editor/form-editor.component.tsx
@@ -79,6 +79,7 @@ const FormEditor: React.FC = () => {
   const [publishedWithErrors, setPublishedWithErrors] = useState(false);
   const [errors, setErrors] = useState<Array<MarkerProps>>([]);
   const [validationOn, setValidationOn] = useState(false);
+  const { blockRenderingWithErrors } = useConfig();
 
   const isLoadingFormOrSchema = Boolean(formUuid) && (isLoadingClobdata || isLoadingForm);
 
@@ -215,7 +216,6 @@ const FormEditor: React.FC = () => {
 
   const renderSchemaChanges = useCallback(() => {
     resetErrorMessage();
-    setValidationOn(true);
     {
       try {
         const parsedJson: Schema = JSON.parse(stringifiedSchema);
@@ -228,6 +228,18 @@ const FormEditor: React.FC = () => {
       }
     }
   }, [stringifiedSchema, updateSchema, resetErrorMessage]);
+
+  const handleRenderSchemaChanges = () => {
+    if (errors.length && blockRenderingWithErrors) {
+      setValidationOn(true);
+      return;
+    } else if (errors.length && !blockRenderingWithErrors) {
+      setValidationOn(true);
+      renderSchemaChanges();
+    } else {
+      renderSchemaChanges();
+    }
+  };
 
   const DraftSchemaModal = () => {
     return (
@@ -342,7 +354,7 @@ const FormEditor: React.FC = () => {
                       {t('inputDummySchema', 'Input dummy schema')}
                     </Button>
                   ) : null}
-                  <Button kind="ghost" onClick={renderSchemaChanges} disabled={invalidJsonErrorMessage}>
+                  <Button kind="ghost" onClick={handleRenderSchemaChanges} disabled={invalidJsonErrorMessage}>
                     <span>{t('renderChanges', 'Render changes')}</span>
                   </Button>
                 </div>
@@ -405,6 +417,7 @@ const FormEditor: React.FC = () => {
             <ActionButtons
               schema={schema}
               t={t}
+              schemaErrors={errors}
               setPublishedWithErrors={setPublishedWithErrors}
               onFormValidation={onValidateForm}
               setValidationResponse={setValidationResponse}

--- a/src/components/form-editor/form-editor.component.tsx
+++ b/src/components/form-editor/form-editor.component.tsx
@@ -215,9 +215,8 @@ const FormEditor: React.FC = () => {
 
   const renderSchemaChanges = useCallback(() => {
     resetErrorMessage();
-    if (errors.length) {
-      setValidationOn(true);
-    } else {
+    setValidationOn(true);
+    {
       try {
         const parsedJson: Schema = JSON.parse(stringifiedSchema);
         updateSchema(parsedJson);
@@ -228,7 +227,7 @@ const FormEditor: React.FC = () => {
         }
       }
     }
-  }, [stringifiedSchema, updateSchema, resetErrorMessage, errors.length]);
+  }, [stringifiedSchema, updateSchema, resetErrorMessage]);
 
   const DraftSchemaModal = () => {
     return (

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -59,4 +59,9 @@ export const configSchema = {
     _default: false,
     _description: 'Whether to enable form validation',
   },
+  blockRenderingWithErrors: {
+    _type: Type.Boolean,
+    _default: false,
+    _description: 'Whether to enable form validation',
+  },
 };


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR is addressing the issue enabling on and off schema validation via configuration, also during schema validation the user should be shown the validation errors but still be able to render and saving their changes 
## Screenshots
https://www.loom.com/share/cfc15777ebcf4cc6991110cd06a08638
## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
