### PR TITLE
(fix) O3-3254: Remove trailing slash from uploadSchema request

### DIFF
--- a/src/forms.resource.ts
+++ b/src/forms.resource.ts
@@ -44,7 +44,7 @@ export async function uploadSchema(schema: Schema): Promise<string> {
   body.append('file', schemaBlob);
 
   const response = await window
-    .fetch(`${window.openmrsBase}/${restBaseUrl}/clobdata`, {
+    .fetch(`${window.openmrsBase}${restBaseUrl}/clobdata`, {
       body,
       method: 'POST',
     })


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Fixes an issue where a trailing slash in the `clobdata` uploadSchema request is causing the request to fail in custom O3 distros (this was reported by @rugute in the AMRS distro).

## Screenshots

![CleanShot 2024-05-21 at 2  09 27@2x](https://github.com/openmrs/openmrs-esm-form-builder/assets/8509731/fa033eff-c7da-4af6-810b-c29ea05191c6)

## Related Issue

https://openmrs.atlassian.net/browse/O3-3254

## Other
<!-- Anything not covered above -->
