### PR TITLE
(fix) Set serialized schema blob MIME type to `application/json`

### DIFF
--- a/src/forms.resource.ts
+++ b/src/forms.resource.ts
@@ -38,7 +38,7 @@ export async function deleteResource(
 
 export async function uploadSchema(schema: Schema): Promise<string> {
   const schemaBlob = new Blob([JSON.stringify(schema)], {
-    type: undefined,
+    type: 'application/json',
   });
   const body = new FormData();
   body.append('file', schemaBlob);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

When creating a form, the serialized schema gets committed to the backend via a multipart form-data request. Currently, the MIME type of that request is set to `undefined`. This causes a problem in the AMPATH O3 distro where the schema MIME type defaults to `application/octet-stream` and breaks the request. 

In this PR, I've explicitly set the MIME type of the request to `application/json` so the blob is correctly identified as a JSON file. 

## Screenshots

### Failing request in AMRS O3

https://github.com/openmrs/openmrs-esm-form-builder/assets/8509731/dfbb9249-1e73-4959-bfd5-a8c5364b3e47

### Fix

https://github.com/openmrs/openmrs-esm-form-builder/assets/8509731/305830e0-1cc5-42f6-9448-bda239e73d72

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
