### PR TITLE
(feat) O3-3368: Support editing encounterDatetime fields in the edit question modal

### DIFF
--- a/src/components/interactive-builder/edit-question.modal.tsx
+++ b/src/components/interactive-builder/edit-question.modal.tsx
@@ -71,6 +71,14 @@ interface ProgramStateData {
   selectedItems: Array<ProgramState>;
 }
 
+const DatePickerType = {
+  both: 'both',
+  calendar: 'calendar',
+  timer: 'timer',
+} as const;
+
+type DatePickerTypeValue = (typeof DatePickerType)[keyof typeof DatePickerType];
+
 const EditQuestionModal: React.FC<EditQuestionModalProps> = ({
   closeModal,
   onSchemaChange,
@@ -115,6 +123,9 @@ const EditQuestionModal: React.FC<EditQuestionModalProps> = ({
   const { concepts, isLoadingConcepts } = useConceptLookup(conceptToLookup);
   const { conceptName, conceptNameLookupError, isLoadingConceptName } = useConceptName(
     questionToEdit.questionOptions.concept,
+  );
+  const [datePickerType, setDatePickerType] = useState<(typeof DatePickerType)[DatePickerTypeValue]>(
+    DatePickerType.both,
   );
   const { patientIdentifierTypes } = usePatientIdentifierTypes();
   const { personAttributeTypes } = usePersonAttributeTypes();
@@ -266,6 +277,7 @@ const EditQuestionModal: React.FC<EditQuestionModalProps> = ({
           ...(addInlineDate && {
             showDate: addInlineDate ? addInlineDate : /true/.test(questionToEdit.questionOptions.showDate.toString()),
           }),
+          datePickerType: datePickerType ? datePickerType : questionToEdit?.datePickerType,
           attributeType: selectedPersonAttributeType
             ? selectedPersonAttributeType['uuid']
             : questionToEdit.questionOptions.attributeType,
@@ -435,6 +447,36 @@ const EditQuestionModal: React.FC<EditQuestionModalProps> = ({
               />
             ) : null}
 
+            {questionToEdit.type === 'encounterDatetime' ? (
+              <RadioButtonGroup
+                defaultSelected="both"
+                name="datePickerType"
+                legendText={t('datePickerType', 'The type of date picker to show ')}
+              >
+                <RadioButton
+                  id="both"
+                  defaultChecked={true}
+                  labelText={t('calendarAndTimer', 'Calendar and timer')}
+                  onClick={() => setDatePickerType(DatePickerType.both)}
+                  value="both"
+                />
+                <RadioButton
+                  id="calendar"
+                  defaultChecked={false}
+                  labelText={t('calendarOnly', 'Calendar only')}
+                  onClick={() => setDatePickerType(DatePickerType.calendar)}
+                  value="calendar"
+                />
+                <RadioButton
+                  id="timer"
+                  defaultChecked={false}
+                  labelText={t('timerOnly', 'Timer only')}
+                  onClick={() => setDatePickerType(DatePickerType.timer)}
+                  value="timer"
+                />
+              </RadioButtonGroup>
+            ) : null}
+
             {questionToEdit.type === 'patientIdentifier' && (
               <div>
                 <FormLabel className={styles.label}>
@@ -578,6 +620,7 @@ const EditQuestionModal: React.FC<EditQuestionModalProps> = ({
             )}
 
             {fieldType !== 'ui-select-extended' &&
+              questionToEdit.type !== 'encounterDatetime' &&
               (questionType === 'obs' || (!questionType && questionToEdit.type === 'obs')) && (
                 <>
                   <div>

--- a/src/components/interactive-builder/edit-question.modal.tsx
+++ b/src/components/interactive-builder/edit-question.modal.tsx
@@ -124,7 +124,7 @@ const EditQuestionModal: React.FC<EditQuestionModalProps> = ({
   const { conceptName, conceptNameLookupError, isLoadingConceptName } = useConceptName(
     questionToEdit.questionOptions.concept,
   );
-  const [datePickerType, setDatePickerType] = useState<(typeof DatePickerType)[DatePickerTypeValue]>(
+  const [datePickerFormat, setDatePickerFormat] = useState<(typeof DatePickerType)[DatePickerTypeValue]>(
     DatePickerType.both,
   );
   const { patientIdentifierTypes } = usePatientIdentifierTypes();
@@ -261,14 +261,19 @@ const EditQuestionModal: React.FC<EditQuestionModalProps> = ({
         type: questionType ? questionType : questionToEdit.type,
         required: isQuestionRequired ? isQuestionRequired : /true/.test(questionToEdit?.required?.toString()),
         id: questionId ? questionId : questionToEdit.id,
+        ...(datePickerFormat && {
+          datePickerFormat: datePickerFormat,
+        }),
         questionOptions: {
           rendering: fieldType ? fieldType : questionToEdit.questionOptions.rendering,
           concept: selectedConcept?.uuid ? selectedConcept.uuid : questionToEdit.questionOptions.concept,
           conceptMappings: conceptMappings?.length ? conceptMappings : questionToEdit.questionOptions.conceptMappings,
           answers: mappedAnswers,
-          identifierType: selectedPatientIdentifierType
-            ? selectedPatientIdentifierType['uuid']
-            : questionToEdit.questionOptions.identifierType,
+          ...(questionType === 'patientIdentifier' && {
+            identifierType: selectedPatientIdentifierType
+              ? selectedPatientIdentifierType['uuid']
+              : questionToEdit.questionOptions.identifierType,
+          }),
           ...(addObsComment && {
             showComment: addObsComment
               ? addObsComment
@@ -277,7 +282,6 @@ const EditQuestionModal: React.FC<EditQuestionModalProps> = ({
           ...(addInlineDate && {
             showDate: addInlineDate ? addInlineDate : /true/.test(questionToEdit.questionOptions.showDate.toString()),
           }),
-          datePickerType: datePickerType ? datePickerType : questionToEdit?.datePickerType,
           attributeType: selectedPersonAttributeType
             ? selectedPersonAttributeType['uuid']
             : questionToEdit.questionOptions.attributeType,
@@ -449,29 +453,26 @@ const EditQuestionModal: React.FC<EditQuestionModalProps> = ({
 
             {questionToEdit.type === 'encounterDatetime' ? (
               <RadioButtonGroup
-                defaultSelected="both"
-                name="datePickerType"
+                defaultSelected={questionToEdit?.datePickerFormat}
+                name="datePickerFormat"
                 legendText={t('datePickerType', 'The type of date picker to show ')}
               >
                 <RadioButton
                   id="both"
-                  defaultChecked={true}
                   labelText={t('calendarAndTimer', 'Calendar and timer')}
-                  onClick={() => setDatePickerType(DatePickerType.both)}
+                  onClick={() => setDatePickerFormat(DatePickerType.both)}
                   value="both"
                 />
                 <RadioButton
                   id="calendar"
-                  defaultChecked={false}
                   labelText={t('calendarOnly', 'Calendar only')}
-                  onClick={() => setDatePickerType(DatePickerType.calendar)}
+                  onClick={() => setDatePickerFormat(DatePickerType.calendar)}
                   value="calendar"
                 />
                 <RadioButton
                   id="timer"
-                  defaultChecked={false}
                   labelText={t('timerOnly', 'Timer only')}
-                  onClick={() => setDatePickerType(DatePickerType.timer)}
+                  onClick={() => setDatePickerFormat(DatePickerType.timer)}
                   value="timer"
                 />
               </RadioButtonGroup>

--- a/src/types.ts
+++ b/src/types.ts
@@ -116,7 +116,7 @@ export interface Question {
   label: string;
   type: string;
   questionOptions: QuestionOptions;
-  datePickerType?: string;
+  datePickerFormat?: string;
   questions?: Array<Question>;
   required?: string | boolean | RequiredFieldProps;
   validators?: Array<Record<string, string>>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -116,6 +116,7 @@ export interface Question {
   label: string;
   type: string;
   questionOptions: QuestionOptions;
+  datePickerType?: string;
   questions?: Array<Question>;
   required?: string | boolean | RequiredFieldProps;
   validators?: Array<Record<string, string>>;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR makes it possible to edit fields of type `encounterDatetime` using the Edit Question modal in the Interactive Builder.

## Screenshots

https://www.loom.com/share/a011912c9e1245968457afc93d1b2192

## Related Issue
https://openmrs.atlassian.net/browse/O3-3368

## Other
<!-- Anything not covered above -->
