### PR TITLE
(fix): Rename datePickerType prop to datePickerFormat

### DIFF
--- a/src/components/interactive-builder/add-question-modal.component.tsx
+++ b/src/components/interactive-builder/add-question-modal.component.tsx
@@ -184,7 +184,7 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
         type: questionType,
         required: isQuestionRequired,
         id: questionId ?? computedQuestionId,
-        ...(questionType === 'encounterDatetime' && { datePickerType }),
+        ...(questionType === 'encounterDatetime' && { datePickerFormat: datePickerType }),
         questionOptions: {
           rendering: renderingType,
           concept: selectedConcept?.uuid,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Question definitions for fields using the `date` rendering type accept an optional `datePickerFormat` prop in the [Angular Form Engine](https://github.com/openmrs/openmrs-ngx-formentry/blob/main/projects/ngx-formentry/src/form-entry/question-models/question-base.ts#L17). This property determines whether to show a:

- Standalone Datepicker
- Datepicker and an accompanying Timepicker
- Timepicker only 

In the AddQuestion modal of the form builder, this properly is incorrectly named `datePickerType`. 

This PR renames the prop back to `datePickerFormat` to maintain parity with the Angular Form Engine.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
**All current schemas would have to be updated to use the correct prop name**