### PR TITLE
(fix) Lift up showSchemaSaveWarning state

### DIFF
--- a/src/components/dashboard/dashboard.component.tsx
+++ b/src/components/dashboard/dashboard.component.tsx
@@ -248,7 +248,6 @@ function ActionButtons({ form, mutate, responsiveSize, t }: ActionButtonsProps) 
 
 function FormsList({ forms, isValidating, mutate, t }: FormsListProps) {
   const pageSize = 10;
-  const config = useConfig<ConfigObject>();
   const isTablet = useLayoutType() === 'tablet';
   const responsiveSize = isTablet ? 'lg' : 'sm';
   const [filter, setFilter] = useState('');
@@ -339,17 +338,6 @@ function FormsList({ forms, isValidating, mutate, t }: FormsListProps) {
 
   return (
     <>
-      {config.showSchemaSaveWarning && (
-        <InlineNotification
-          className={styles.warningMessage}
-          kind="info"
-          lowContrast
-          title={t(
-            'schemaSaveWarningMessage',
-            "The dev3 server is ephemeral at best and can't be relied upon to save your schemas permanently. To avoid losing your work, please save your schemas to your local machine. Alternatively, upload your schema to the distro repo to have it persisted across server resets.",
-          )}
-        />
-      )}
       <div className={styles.flexContainer}>
         <div className={styles.filterContainer}>
           <Dropdown
@@ -447,6 +435,7 @@ function FormsList({ forms, isValidating, mutate, t }: FormsListProps) {
 const Dashboard: React.FC = () => {
   const { t } = useTranslation();
   const { forms, error, isLoading, isValidating, mutate } = useForms();
+  const { showSchemaSaveWarning } = useConfig<ConfigObject>();
 
   return (
     <main>
@@ -465,7 +454,22 @@ const Dashboard: React.FC = () => {
             return <EmptyState />;
           }
 
-          return <FormsList forms={forms} isValidating={isValidating} mutate={mutate} t={t} />;
+          return (
+            <>
+              {showSchemaSaveWarning && (
+                <InlineNotification
+                  className={styles.warningMessage}
+                  kind="info"
+                  lowContrast
+                  title={t(
+                    'schemaSaveWarningMessage',
+                    "The dev3 server is ephemeral at best and can't be relied upon to save your schemas permanently. To avoid losing your work, please save your schemas to your local machine. Alternatively, upload your schema to the distro repo to have it persisted across server resets.",
+                  )}
+                />
+              )}
+              <FormsList forms={forms} isValidating={isValidating} mutate={mutate} t={t} />
+            </>
+          );
         })()}
       </div>
     </main>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This change [lifts up](https://react.dev/learn/sharing-state-between-components#lifting-state-up-by-example) the `showSchemaSaveWarning` state, saving us a spurious re-render each time the `FormsList` component re-renders.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
