### PR TITLE
(fix) Use state uuid as opposed to concept uuid in program state inte…

### DIFF
--- a/src/components/interactive-builder/add-question.modal.tsx
+++ b/src/components/interactive-builder/add-question.modal.tsx
@@ -238,7 +238,7 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
             selectedConcept?.allowDecimal === false && { disallowDecimals: true }),
           ...(questionType === 'programState' && {
             answers: selectedProgramState.map((answer) => ({
-              value: answer.concept.uuid,
+              value: answer.uuid,
               label: answer.concept.display,
             })),
             programUuid: selectedProgram.uuid,

--- a/src/components/interactive-builder/edit-question.modal.tsx
+++ b/src/components/interactive-builder/edit-question.modal.tsx
@@ -253,7 +253,7 @@ const EditQuestionModal: React.FC<EditQuestionModalProps> = ({
     } else {
       if (questionToEdit.type === 'programState') {
         mappedAnswers = selectedProgramState.map((answer) => ({
-          value: answer.concept.uuid,
+          value: answer.uuid,
           label: answer.concept.display,
         }));
       } else {
@@ -350,7 +350,7 @@ const EditQuestionModal: React.FC<EditQuestionModalProps> = ({
 
   useEffect(() => {
     const previousStates = programWorkflow?.states.filter((state) =>
-      questionToEdit.questionOptions.answers.some((answer) => answer.value === state.concept.uuid),
+      questionToEdit.questionOptions.answers.some((answer) => answer.value === state.uuid),
     );
     setSelectedProgramState(previousStates);
   }, [programWorkflow, questionToEdit.questionOptions.answers]);


### PR DESCRIPTION
…ractive view

## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
- Use state uuid as opposed to concept uuid in program state questions in interactive view

## Screenshots
<!-- Required if you are making UI changes. -->
<img width="1720" alt="Screenshot 2024-07-09 at 11 40 29" src="https://github.com/openmrs/openmrs-esm-form-builder/assets/19533785/3a7e1d72-909b-4eac-b27a-d2977d170cec">

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
