### PR TITLE
(fix) Reset previous errors on schema update

### DIFF
--- a/src/components/form-editor/form-editor.component.tsx
+++ b/src/components/form-editor/form-editor.component.tsx
@@ -77,12 +77,21 @@ const FormEditorContent: React.FC<TranslationFnProps> = ({ t }) => {
   const [publishedWithErrors, setPublishedWithErrors] = useState(false);
   const [errors, setErrors] = useState<Array<MarkerProps>>([]);
   const [validationOn, setValidationOn] = useState(false);
+  const [invalidJsonErrorMessage, setInvalidJsonErrorMessage] = useState('');
 
   const isLoadingFormOrSchema = Boolean(formUuid) && (isLoadingClobdata || isLoadingForm);
 
-  const handleSchemaChange = useCallback((updatedSchema: string) => {
-    setStringifiedSchema(updatedSchema);
+  const resetErrorMessage = useCallback(() => {
+    setInvalidJsonErrorMessage('');
   }, []);
+
+  const handleSchemaChange = useCallback(
+    (updatedSchema: string) => {
+      resetErrorMessage();
+      setStringifiedSchema(updatedSchema);
+    },
+    [resetErrorMessage],
+  );
 
   const launchRestoreDraftSchemaModal = useCallback(() => {
     const dispose = showModal('restore-draft-schema-modal', {
@@ -198,12 +207,6 @@ const FormEditorContent: React.FC<TranslationFnProps> = ({ t }) => {
     setStringifiedSchema(JSON.stringify(dummySchema, null, 2));
     updateSchema({ ...dummySchema });
   }, [updateSchema]);
-
-  const [invalidJsonErrorMessage, setInvalidJsonErrorMessage] = useState('');
-
-  const resetErrorMessage = useCallback(() => {
-    setInvalidJsonErrorMessage('');
-  }, []);
 
   const renderSchemaChanges = useCallback(() => {
     resetErrorMessage();


### PR DESCRIPTION
## Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This ensures that errors encountered previously while compiling the schema are reset upon updating the schema. This ensures that the "Render changes" button is enabled upon resolving the previously flagged errors.

## Screenshots
<!-- Required if you are making UI changes. -->

Issue:

![2024-07-12 19-51-38 2024-07-12 19_54_00](https://github.com/user-attachments/assets/60dea2a9-56b1-4f1d-99c4-e6a422ed17e1)

Fixed:

![2024-07-12 19-54-59 2024-07-12 19_55_56](https://github.com/user-attachments/assets/374401ff-d353-418c-a956-3881ab64da85)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
N/A

## Other
<!-- Anything not covered above -->
