### PR TITLE
(fix) Fix modal header close button styles

### DIFF
--- a/src/components/action-buttons/action-buttons.scss
+++ b/src/components/action-buttons/action-buttons.scss
@@ -4,7 +4,7 @@
   justify-content: flex-end;
   margin: 1rem 0;
 
-  button {
+  > button {
     margin-left: 1rem
   }
 }

--- a/src/components/action-buttons/unpublish-form.modal.tsx
+++ b/src/components/action-buttons/unpublish-form.modal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, ModalBody, ModalHeader, ModalFooter } from '@carbon/react';
+import styles from '../modals.scss';
 
 interface UnpublishModalProps {
   closeModal: () => void;
@@ -13,6 +14,7 @@ const UnpublishFormModal: React.FC<UnpublishModalProps> = ({ closeModal, onUnpub
   return (
     <>
       <ModalHeader
+        className={styles.modalHeader}
         closeModal={closeModal}
         title={t('unpublishConfirmation', 'Are you sure you want to unpublish this form?')}
       />

--- a/src/components/dashboard/delete-form.scss
+++ b/src/components/dashboard/delete-form.scss
@@ -1,3 +1,5 @@
+@use '@carbon/layout';
+
 .spinner {
   &:global(.cds--inline-loading) {
     min-height: 1rem;
@@ -5,5 +7,33 @@
 
   :global(.cds--inline-loading__text) {
     font-size: unset;
+  }
+}
+
+.modalHeader {
+  :global {
+    .cds--modal-close-button {
+      position: absolute;
+      inset-block-start: 0;
+      inset-inline-end: 0;
+      margin: 0;
+      margin-top: calc(-1 * #{layout.$spacing-05});
+    }
+
+    .cds--modal-close {
+      background-color: rgba(0, 0, 0, 0);
+
+      &:hover {
+        background-color: var(--cds-layer-hover);
+      }
+    }
+
+    .cds--popover--left > .cds--popover > .cds--popover-content {
+      transform: translate(-4rem, 0.85rem);
+    }
+
+    .cds--popover--left > .cds--popover > .cds--popover-caret {
+      transform: translate(-3.75rem, 1.25rem);
+    }
   }
 }

--- a/src/components/form-editor/form-editor.scss
+++ b/src/components/form-editor/form-editor.scss
@@ -2,6 +2,32 @@
 @use '@carbon/layout';
 @use "@carbon/type";
 
+:global {
+  .cds--modal-close-button {
+    position: absolute;
+    inset-block-start: 0;
+    inset-inline-end: 0;
+    margin: 0;
+    margin-top: calc(-1 * #{layout.$spacing-05});
+  }
+
+  .cds--modal-close {
+    background-color: rgba(0, 0, 0, 0);
+
+    &:hover {
+      background-color: var(--cds-layer-hover);
+    }
+  }
+
+  .cds--popover--left > .cds--popover > .cds--popover-content {
+    transform: translate(-4rem, 0.85rem);
+  }
+
+  .cds--popover--left > .cds--popover > .cds--popover-caret {
+    transform: translate(-3.75rem, 1.25rem);
+  }
+}
+
 .container {
   padding: 1rem 2rem;
   display: flex;

--- a/src/components/form-editor/form-editor.scss
+++ b/src/components/form-editor/form-editor.scss
@@ -2,32 +2,6 @@
 @use '@carbon/layout';
 @use "@carbon/type";
 
-:global {
-  .cds--modal-close-button {
-    position: absolute;
-    inset-block-start: 0;
-    inset-inline-end: 0;
-    margin: 0;
-    margin-top: calc(-1 * #{layout.$spacing-05});
-  }
-
-  .cds--modal-close {
-    background-color: rgba(0, 0, 0, 0);
-
-    &:hover {
-      background-color: var(--cds-layer-hover);
-    }
-  }
-
-  .cds--popover--left > .cds--popover > .cds--popover-content {
-    transform: translate(-4rem, 0.85rem);
-  }
-
-  .cds--popover--left > .cds--popover > .cds--popover-caret {
-    transform: translate(-3.75rem, 1.25rem);
-  }
-}
-
 .container {
   padding: 1rem 2rem;
   display: flex;

--- a/src/components/form-editor/restore-draft-schema.modal.tsx
+++ b/src/components/form-editor/restore-draft-schema.modal.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, Form, ModalBody, ModalHeader, ModalFooter } from '@carbon/react';
 import { type Schema } from '../../types';
+import styles from '../modals.scss';
 
 interface RestoreDraftSchemaModalProps {
   closeModal: () => void;
@@ -24,7 +25,11 @@ const RestoreDraftSchemaModal: React.FC<RestoreDraftSchemaModalProps> = ({ close
 
   return (
     <>
-      <ModalHeader closeModal={closeModal} title={t('schemaNotFound', 'Schema not found')} />
+      <ModalHeader
+        className={styles.modalHeader}
+        closeModal={closeModal}
+        title={t('schemaNotFound', 'Schema not found')}
+      />
       <Form onSubmit={(event: React.SyntheticEvent) => event.preventDefault()}>
         <ModalBody>
           <p>

--- a/src/components/interactive-builder/add-question.modal.tsx
+++ b/src/components/interactive-builder/add-question.modal.tsx
@@ -7,9 +7,9 @@ import {
   Form,
   FormGroup,
   FormLabel,
-  Layer,
   InlineLoading,
   InlineNotification,
+  Layer,
   ModalBody,
   ModalFooter,
   ModalHeader,
@@ -19,11 +19,11 @@ import {
   Search,
   Select,
   SelectItem,
+  SelectSkeleton,
   Stack,
   Tag,
   TextInput,
   Tile,
-  SelectSkeleton,
 } from '@carbon/react';
 import { ArrowUpRight } from '@carbon/react/icons';
 import { showSnackbar, useConfig, useDebounce } from '@openmrs/esm-framework';
@@ -46,8 +46,8 @@ import type {
 import { useConceptLookup } from '../../hooks/useConceptLookup';
 import { usePatientIdentifierTypes } from '../../hooks/usePatientIdentifierTypes';
 import { usePersonAttributeTypes } from '../../hooks/usePersonAttributeTypes';
-import styles from './question-modal.scss';
 import { useProgramWorkStates, usePrograms } from '../../hooks/useProgramStates';
+import styles from './question-modal.scss';
 
 interface AddQuestionModalProps {
   closeModal: () => void;
@@ -303,7 +303,11 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
 
   return (
     <>
-      <ModalHeader title={t('createNewQuestion', 'Create a new question')} closeModal={closeModal} />
+      <ModalHeader
+        className={styles.modalHeader}
+        title={t('createNewQuestion', 'Create a new question')}
+        closeModal={closeModal}
+      />
       <Form className={styles.form} onSubmit={(event: React.SyntheticEvent) => event.preventDefault()}>
         <ModalBody hasScrollingContent>
           <FormGroup legendText={''}>
@@ -701,8 +705,8 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
                   name="datePickerType"
                   legendText={t('datePickerType', 'The type of date picker to show ')}
                 >
-                  {/** Filters out the date picker types based on the selected concept's data type. 
-                       If no concept is selected, all date picker types are shown. 
+                  {/** Filters out the date picker types based on the selected concept's data type.
+                       If no concept is selected, all date picker types are shown.
                   */}
                   {selectedConcept && selectedConcept.datatype
                     ? datePickerTypeOptions[selectedConcept.datatype.name.toLowerCase()].map((type) => (

--- a/src/components/interactive-builder/delete-page.modal.tsx
+++ b/src/components/interactive-builder/delete-page.modal.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Button, ModalBody, ModalFooter, ModalHeader } from '@carbon/react';
 import { showSnackbar } from '@openmrs/esm-framework';
 import type { Schema } from '../../types';
+import styles from '../modals.scss';
 
 interface DeletePageModalProps {
   closeModal: () => void;
@@ -40,6 +41,7 @@ const DeletePageModal: React.FC<DeletePageModalProps> = ({ onSchemaChange, pageI
   return (
     <>
       <ModalHeader
+        className={styles.modalHeader}
         title={t('deletePageConfirmation', 'Are you sure you want to delete this page?')}
         closeModal={closeModal}
       />

--- a/src/components/interactive-builder/delete-question.modal.tsx
+++ b/src/components/interactive-builder/delete-question.modal.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Button, ModalBody, ModalFooter, ModalHeader } from '@carbon/react';
 import { showSnackbar } from '@openmrs/esm-framework';
 import type { Question, Schema } from '../../types';
+import styles from '../modals.scss';
 
 interface DeleteQuestionModal {
   closeModal: () => void;
@@ -68,6 +69,7 @@ const DeleteQuestionModal: React.FC<DeleteQuestionModal> = ({
   return (
     <div>
       <ModalHeader
+        className={styles.modalHeader}
         closeModal={closeModal}
         title={t('deleteQuestionConfirmation', 'Are you sure you want to delete this question? ')}
       />

--- a/src/components/interactive-builder/delete-section.modal.tsx
+++ b/src/components/interactive-builder/delete-section.modal.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Button, ModalBody, ModalFooter, ModalHeader } from '@carbon/react';
 import { showSnackbar } from '@openmrs/esm-framework';
 import type { Schema } from '../../types';
+import styles from '../modals.scss';
 
 interface DeleteSectionModal {
   closeModal: () => void;
@@ -47,6 +48,7 @@ const DeleteSectionModal: React.FC<DeleteSectionModal> = ({
   return (
     <>
       <ModalHeader
+        className={styles.modalHeader}
         title={t('deleteSectionConfirmation', 'Are you sure you want to delete this section?')}
         closeModal={closeModal}
       />

--- a/src/components/interactive-builder/edit-question.modal.tsx
+++ b/src/components/interactive-builder/edit-question.modal.tsx
@@ -52,8 +52,8 @@ import { usePersonAttributeLookup } from '../../hooks/usePersonAttributeLookup';
 import { usePersonAttributeName } from '../../hooks/usePersonAttributeName';
 import { usePersonAttributeTypes } from '../../hooks/usePersonAttributeTypes';
 import { usePrograms, useProgramWorkStates } from '../../hooks/useProgramStates';
-import styles from './question-modal.scss';
 import { getDatePickerType } from './add-question.modal';
+import styles from './question-modal.scss';
 
 interface EditQuestionModalProps {
   closeModal: () => void;
@@ -357,7 +357,7 @@ const EditQuestionModal: React.FC<EditQuestionModalProps> = ({
 
   return (
     <>
-      <ModalHeader closeModal={closeModal} title={t('editQuestion', 'Edit question')} />
+      <ModalHeader className={styles.modalHeader} closeModal={closeModal} title={t('editQuestion', 'Edit question')} />
       <Form className={styles.form} onSubmit={(event: React.SyntheticEvent) => event.preventDefault()}>
         <ModalBody hasScrollingContent>
           <Stack gap={5}>
@@ -832,8 +832,8 @@ const EditQuestionModal: React.FC<EditQuestionModalProps> = ({
                 name="datePickerType"
                 legendText={t('datePickerType', 'The type of date picker to show')}
               >
-                {/** Filters out the date picker types based on the selected concept's data type. 
-                     If no concept is selected, all date picker types are shown. 
+                {/** Filters out the date picker types based on the selected concept's data type.
+                     If no concept is selected, all date picker types are shown.
                 */}
                 {selectedConcept && selectedConcept.datatype
                   ? datePickerTypeOptions[selectedConcept.datatype.name.toLowerCase()].map((type) => (

--- a/src/components/interactive-builder/new-form.modal.tsx
+++ b/src/components/interactive-builder/new-form.modal.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Button, Form, FormGroup, ModalBody, ModalFooter, ModalHeader, Stack, TextInput } from '@carbon/react';
 import { showSnackbar } from '@openmrs/esm-framework';
 import type { Schema } from '../../types';
+import styles from '../modals.scss';
 
 interface NewFormModalProps {
   schema: Schema;
@@ -50,7 +51,11 @@ const NewFormModal: React.FC<NewFormModalProps> = ({ schema, onSchemaChange, clo
 
   return (
     <>
-      <ModalHeader closeModal={closeModal} title={t('createNewForm', 'Create a new form')} />
+      <ModalHeader
+        className={styles.modalHeader}
+        closeModal={closeModal}
+        title={t('createNewForm', 'Create a new form')}
+      />
       <Form onSubmit={(event: React.SyntheticEvent) => event.preventDefault()}>
         <ModalBody>
           <Stack gap={5}>

--- a/src/components/interactive-builder/page.modal.tsx
+++ b/src/components/interactive-builder/page.modal.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Button, Form, FormGroup, ModalBody, ModalFooter, ModalHeader, TextInput } from '@carbon/react';
 import { showSnackbar } from '@openmrs/esm-framework';
 import type { Schema } from '../../types';
+import styles from '../modals.scss';
 
 interface PageModalProps {
   closeModal: () => void;
@@ -49,7 +50,11 @@ const PageModal: React.FC<PageModalProps> = ({ closeModal, schema, onSchemaChang
 
   return (
     <>
-      <ModalHeader title={t('createNewPage', 'Create a new page')} closeModal={closeModal} />
+      <ModalHeader
+        className={styles.modalHeader}
+        title={t('createNewPage', 'Create a new page')}
+        closeModal={closeModal}
+      />
       <Form onSubmit={(event: React.SyntheticEvent) => event.preventDefault()}>
         <ModalBody>
           <FormGroup legendText={''}>

--- a/src/components/interactive-builder/question-modal.scss
+++ b/src/components/interactive-builder/question-modal.scss
@@ -1,4 +1,5 @@
 @use '@carbon/colors';
+@use '@carbon/layout';
 @use "@carbon/type";
 
 .label {
@@ -125,4 +126,32 @@
 .required {
   color: colors.$red-60;
   margin-left: 0.125rem;
+}
+
+.modalHeader {
+  :global {
+    .cds--modal-close-button {
+      position: absolute;
+      inset-block-start: 0;
+      inset-inline-end: 0;
+      margin: 0;
+      margin-top: calc(-1 * #{layout.$spacing-05});
+    }
+
+    .cds--modal-close {
+      background-color: rgba(0, 0, 0, 0);
+
+      &:hover {
+        background-color: var(--cds-layer-hover);
+      }
+    }
+
+    .cds--popover--left > .cds--popover > .cds--popover-content {
+      transform: translate(-4rem, 0.85rem);
+    }
+
+    .cds--popover--left > .cds--popover > .cds--popover-caret {
+      transform: translate(-3.75rem, 1.25rem);
+    }
+  }
 }

--- a/src/components/interactive-builder/section.modal.tsx
+++ b/src/components/interactive-builder/section.modal.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Button, Form, FormGroup, ModalBody, ModalFooter, ModalHeader, TextInput } from '@carbon/react';
 import { showSnackbar } from '@openmrs/esm-framework';
 import type { Schema } from '../../types';
+import styles from '../modals.scss';
 
 interface SectionModalProps {
   closeModal: () => void;
@@ -49,7 +50,11 @@ const SectionModal: React.FC<SectionModalProps> = ({ closeModal, schema, onSchem
 
   return (
     <>
-      <ModalHeader title={t('createNewSection', 'Create a new section')} closeModal={closeModal} />
+      <ModalHeader
+        className={styles.modalHeader}
+        title={t('createNewSection', 'Create a new section')}
+        closeModal={closeModal}
+      />
       <Form onSubmit={(event: React.SyntheticEvent) => event.preventDefault()}>
         <ModalBody>
           <FormGroup legendText={''}>

--- a/src/components/modals.scss
+++ b/src/components/modals.scss
@@ -1,20 +1,5 @@
 @use '@carbon/layout';
 
-.spinner {
-  &:global(.cds--inline-loading) {
-    min-height: 1rem;
-  }
-
-  :global(.cds--inline-loading__text) {
-    font-size: unset;
-  }
-}
-
-.saveFormBody {
-  max-height: 75vh;
-  overflow-y: auto;
-}
-
 .modalHeader {
   :global {
     .cds--modal-close-button {

--- a/src/components/modals/save-form.modal.tsx
+++ b/src/components/modals/save-form.modal.tsx
@@ -230,7 +230,7 @@ const SaveFormModal: React.FC<SaveFormModalProps> = ({ form, schema }) => {
           onClose={() => setOpenConfirmSaveModal(false)}
           preventCloseOnClickOutside
         >
-          <ModalHeader title={t('saveConfirmation', 'Save or Update form')} />
+          <ModalHeader className={styles.modalHeader} title={t('saveConfirmation', 'Save or Update form')} />
           <ModalBody>
             <p>
               {t(
@@ -254,7 +254,7 @@ const SaveFormModal: React.FC<SaveFormModalProps> = ({ form, schema }) => {
       ) : null}
 
       <ComposedModal open={openSaveFormModal} onClose={() => setOpenSaveFormModal(false)} preventCloseOnClickOutside>
-        <ModalHeader title={t('saveFormToServer', 'Save form to server')} />
+        <ModalHeader className={styles.modalHeader} title={t('saveFormToServer', 'Save form to server')} />
         <Form onSubmit={handleSubmit} className={styles.saveFormBody}>
           <ModalBody>
             <p>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR implements a temporary fix for the broken styling of the [ComposedModal](https://react.carbondesignsystem.com/?path=/docs/components-composedmodal--overview) component's close button. The issue appears to be caused by a version mismatch in the Carbon Design System.

This patch uses scoped global styles to adjust the close button and its tooltip to approximate the intended design. While not an ideal solution, it ensures the component remains functional and visually consistent for now.

The long-term resolution will involve updating Carbon dependencies across the project to align with the latest version. However, this immediate fix addresses the urgent styling break caused by the recent Carbon version upgrade in this repository.

## Screenshots

### Before

https://github.com/user-attachments/assets/8faa28c2-c1aa-46bd-9c4f-a2efbdb63f3a

### After

https://github.com/user-attachments/assets/c00d42df-7935-445d-acc1-72dbcc276cb8

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
