### PR TITLE
(fix) Fix delete page IconButton size

### DIFF
--- a/src/components/interactive-builder/interactive-builder.component.tsx
+++ b/src/components/interactive-builder/interactive-builder.component.tsx
@@ -379,7 +379,7 @@ const InteractiveBuilder: React.FC<InteractiveBuilderProps> = ({
                     label={t('deletePage', 'Delete page')}
                     kind="ghost"
                     onClick={() => launchDeletePageModal(pageIndex)}
-                    size="sm"
+                    size="md"
                   >
                     <TrashCan />
                   </IconButton>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Follow-up to #331. Fixes the size of the `Delete page` IconButton to match the other IconButtons on the page.

## Screenshots

![CleanShot 2024-07-23 at 12  32 15@2x](https://github.com/user-attachments/assets/0d97cbe4-69d6-495c-bf90-e466a2a7dd4f)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
