### PR TITLE
(fix) O3-3713: Should not go into infinite loading when conceptId is undefined

### DIFF
--- a/src/components/interactive-builder/edit-question.modal.tsx
+++ b/src/components/interactive-builder/edit-question.modal.tsx
@@ -144,7 +144,10 @@ const EditQuestionModal: React.FC<EditQuestionModalProps> = ({
   );
   const [programWorkflows, setProgramWorkflows] = useState<Array<ProgramWorkflow>>([]);
 
-  const hasConceptChanged = selectedConcept && questionToEdit?.questionOptions?.concept !== selectedConcept?.uuid;
+  const hasConceptChanged =
+    selectedConcept &&
+    questionToEdit?.questionOptions.concept &&
+    questionToEdit?.questionOptions?.concept !== selectedConcept?.uuid;
   const [addInlineDate, setAddInlineDate] = useState(false);
 
   // Maps the data type of a concept to a date picker type.
@@ -276,8 +279,8 @@ const EditQuestionModal: React.FC<EditQuestionModalProps> = ({
           rendering: fieldType ? fieldType : questionToEdit.questionOptions.rendering,
           ...((selectedConcept || questionToEdit.questionOptions.concept) && {
             concept: selectedConcept ? selectedConcept.uuid : questionToEdit.questionOptions.concept,
+            conceptMappings: conceptMappings?.length ? conceptMappings : questionToEdit.questionOptions.conceptMappings,
           }),
-          conceptMappings: conceptMappings?.length ? conceptMappings : questionToEdit.questionOptions.conceptMappings,
           answers: mappedAnswers,
           ...(questionType === 'patientIdentifier' && {
             identifierType: selectedPatientIdentifierType

--- a/src/hooks/useConceptName.ts
+++ b/src/hooks/useConceptName.ts
@@ -1,5 +1,6 @@
 import useSWR from 'swr';
 import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
+import { isEmpty } from '@openmrs/openmrs-form-engine-lib';
 
 export function useConceptName(conceptId: string | undefined) {
   const customRepresentation = 'custom:(name:(display))';
@@ -10,6 +11,6 @@ export function useConceptName(conceptId: string | undefined) {
   return {
     conceptName: data?.data?.name?.display ?? null,
     conceptNameLookupError: error,
-    isLoadingConceptName: (!data && !error) || false,
+    isLoadingConceptName: !conceptId || isEmpty(conceptId) ? false : (!data && !error) || false,
   };
 }

--- a/src/hooks/useConceptName.ts
+++ b/src/hooks/useConceptName.ts
@@ -1,6 +1,5 @@
 import useSWR from 'swr';
 import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
-import { isEmpty } from '@openmrs/openmrs-form-engine-lib';
 
 export function useConceptName(conceptId: string | undefined) {
   const customRepresentation = 'custom:(name:(display))';
@@ -11,6 +10,6 @@ export function useConceptName(conceptId: string | undefined) {
   return {
     conceptName: data?.data?.name?.display ?? null,
     conceptNameLookupError: error,
-    isLoadingConceptName: !conceptId || isEmpty(conceptId) ? false : (!data && !error) || false,
+    isLoadingConceptName: (conceptId && !data && !error) || false,
   };
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR fixes the issue of the backing concept field in the `editQuestionModal` going in to an infinite load if there is no concept or if the concept is set to an empty string.

## Screenshots
Before the fix:

https://github.com/user-attachments/assets/59dac41d-f7fe-4ce7-b0dc-b7ff48df3c37

After the fix:

https://github.com/user-attachments/assets/4c7f1fe3-39be-4b99-b4b9-94afeb66dd13

https://github.com/user-attachments/assets/beeeb34f-6999-4280-8acc-bc5aa5529449

<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-3713

## Other
<!-- Anything not covered above -->

