### PR TITLE
(chore) O3-3959: Cache playwright browsers install step in E2E workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -62,8 +62,8 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           server-token: ${{ env.TURBO_TOKEN }}
 
-      - name: Build apps
-        run: yarn turbo run build --color --concurrency=5
+      - name: Build app
+        run: yarn turbo run build --color 
 
       - name: Run dev server
         run: bash e2e/support/github/run-e2e-docker-env.sh
@@ -72,15 +72,15 @@ jobs:
         run: while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8080/openmrs/login.htm)" != "200" ]]; do sleep 10; done
 
       - name: Run E2E tests
-        run: yarn test-e2e
+        run: yarn playwright test
 
       - name: Stop dev server
         if: '!cancelled()'
         run: docker stop $(docker ps -a -q)
 
-      - name: Upload report
+      - name: Upload Report
         uses: actions/upload-artifact@v4
-        if: '!cancelled()'
+        if: always()
         with:
           name: playwright-report
           path: playwright-report/

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,6 +16,7 @@ env:
 jobs:
   run_e2e_tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -63,7 +63,7 @@ jobs:
           server-token: ${{ env.TURBO_TOKEN }}
 
       - name: Build app
-        run: yarn turbo run build --color 
+        run: yarn turbo run build --color
 
       - name: Run dev server
         run: bash e2e/support/github/run-e2e-docker-env.sh

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,7 +16,6 @@ env:
 jobs:
   run_e2e_tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -30,18 +29,31 @@ jobs:
           node-version: 18
 
       - name: Cache dependencies
-        id: cache
+        id: cache-dependencies
         uses: actions/cache@v4
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.cache-dependencies.outputs.cache-hit != 'true'
         run: yarn install --immutable
+
+      - name: Get installed Playwright version
+        id: playwright-version
+        run: echo "PLAYWRIGHT_VERSION=$(grep '@playwright/test@' yarn.lock | sed -n 's/.*npm:\([^":]*\).*/\1/p' | head -n 1)" >> $GITHUB_ENV
+
+      - name: Cache Playwright binaries
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
 
       - name: Install Playwright Browsers
         run: npx playwright install chromium --with-deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
 
       - name: Setup local cache server for Turborepo
         uses: felixmosh/turborepo-gh-artifacts@v3
@@ -49,8 +61,8 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           server-token: ${{ env.TURBO_TOKEN }}
 
-      - name: Build app
-        run: yarn turbo run build --color
+      - name: Build apps
+        run: yarn turbo run build --color --concurrency=5
 
       - name: Run dev server
         run: bash e2e/support/github/run-e2e-docker-env.sh
@@ -59,17 +71,32 @@ jobs:
         run: while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8080/openmrs/login.htm)" != "200" ]]; do sleep 10; done
 
       - name: Run E2E tests
-        run: yarn playwright test
+        run: yarn test-e2e
 
       - name: Stop dev server
         if: '!cancelled()'
         run: docker stop $(docker ps -a -q)
 
-      - name: Upload Report
+      - name: Upload report
         uses: actions/upload-artifact@v4
-        if: always()
+        if: '!cancelled()'
         with:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
+          overwrite: true
+
+      - name: Capture Server Logs
+        if: always()
+        uses: jwalton/gh-docker-logs@v2
+        with:
+          dest: './logs'
+
+      - name: Upload Logs as Artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: server-logs
+          path: './logs'
+          retention-days: 2
           overwrite: true


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
The current end-to-end test GitHub action takes a significant amount of time to install Playwright browsers during every run on the https://github.com/openmrs/openmrs-esm-form-builder/ repo. To improve the efficiency of the CI pipeline, we should cache the Playwright browser installation to reduce the time spent installing browsers on every run.

## Screenshots


## Related Issue
Ticket: https://openmrs.atlassian.net/browse/O3-3959

## Other

