### PR TITLE
 (feat) O3-3712: Add additional concepts as answers to a coded question

### DIFF
--- a/src/components/interactive-builder/add-question.modal.tsx
+++ b/src/components/interactive-builder/add-question.modal.tsx
@@ -736,7 +736,7 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
                       ))}
                     </div>
                   ) : null}
-                  {selectedConcept.datatype?.name === 'Coded' ? (
+                  {selectedConcept && selectedConcept.datatype?.name === 'Coded' ? (
                     <div>
                       <FormLabel className={styles.label}>
                         {t('searchForAnswerConcept', 'Search for a concept to add as an answer')}

--- a/src/components/interactive-builder/add-question.modal.tsx
+++ b/src/components/interactive-builder/add-question.modal.tsx
@@ -107,7 +107,6 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
   const [isQuestionRequired, setIsQuestionRequired] = useState(false);
   const [max, setMax] = useState('');
   const [min, setMin] = useState('');
-  const [addAnswer, setAnswer] = useState(false);
   const [questionId, setQuestionId] = useState('');
   const [questionLabel, setQuestionLabel] = useState('');
   const [questionType, setQuestionType] = useState<QuestionType | null>(null);
@@ -176,7 +175,6 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
   const handleConceptSelect = (concept: Concept) => {
     const updatedDatePickerType = getDatePickerType(concept);
     if (updatedDatePickerType) setDatePickerType(updatedDatePickerType);
-    setAnswer(false);
     setConceptToLookup('');
     setSelectedConcept(concept);
     setAnswers(
@@ -330,35 +328,7 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
         });
       }
     }
-<<<<<<< HEAD
-  }, [
-    onSchemaChange,
-    t,
-    selectedProgram?.uuid,
-    schema,
-    pageIndex,
-    sectionIndex,
-    questionLabel,
-    questionType,
-    isQuestionRequired,
-    questionId,
-    renderingType,
-    datePickerType,
-    selectedConcept,
-    conceptMappings,
-    selectedAnswers,
-    addObsComment,
-    addInlineDate,
-    selectedPersonAttributeType,
-    selectedPatientIdetifierType,
-    selectedProgramState,
-    programWorkflow,
-    toggleLabelTrue,
-    toggleLabelFalse,
-  ]);
-=======
   };
->>>>>>> 1b94b7b (removed callback)
 
   const convertLabelToCamelCase = () => {
     const camelCasedLabel = questionLabel
@@ -368,14 +338,6 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
       })
       .replace(/\s+/g, '');
     setQuestionId(camelCasedLabel);
-  };
-
-  const showAddQuestion = () => {
-    if (!addAnswer) {
-      setAnswer(true);
-      return;
-    }
-    setAnswer(false);
   };
 
   const handleProgramWorkflowChange = (selectedItem: ProgramWorkflow) => {
@@ -774,17 +736,10 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
                       ))}
                     </div>
                   ) : null}
-                  {selectedConcept && answers?.length ? (
-                    <div>
-                      <Button kind="tertiary" onClick={showAddQuestion} iconDescription="Add" size="sm">
-                        More Answers
-                      </Button>
-                    </div>
-                  ) : null}
-                  {addAnswer ? (
+                  {selectedConcept.datatype?.name === 'Coded' ? (
                     <div>
                       <FormLabel className={styles.label}>
-                        {t('searchForAnswerConcept', 'Search for an answer Concept to Add')}
+                        {t('searchForAnswerConcept', 'Search for a concept to add as an answer')}
                       </FormLabel>
                       {conceptAnsLookupError ? (
                         <InlineNotification

--- a/src/components/interactive-builder/add-question.modal.tsx
+++ b/src/components/interactive-builder/add-question.modal.tsx
@@ -118,7 +118,7 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
       text: string;
     }>
   >([]);
-  const [addedAnswers, setaddedAnswers] = useState<
+  const [addedAnswers, setAddedAnswers] = useState<
     Array<{
       id: string;
       text: string;

--- a/src/components/interactive-builder/add-question.modal.tsx
+++ b/src/components/interactive-builder/add-question.modal.tsx
@@ -246,7 +246,7 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
     closeModal();
   };
 
-  const createQuestion = (selectedAnswers) => {
+  const createQuestion = (updatedAnswers) => {
     try {
       const questionIndex = schema.pages[pageIndex]?.sections?.[sectionIndex]?.questions?.length ?? 0;
       const computedQuestionId = `question${questionIndex + 1}Section${sectionIndex + 1}Page-${pageIndex + 1}`;
@@ -264,8 +264,8 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
           ...(max && { max }),
           ...(selectedConcept && { concept: selectedConcept?.uuid }),
           ...(conceptMappings.length && { conceptMappings }),
-          ...(selectedAnswers.length && {
-            answers: selectedAnswers.map((answer) => ({
+          ...(updatedAnswers.length && {
+            answers: updatedAnswers.map((answer) => ({
               concept: answer.id,
               label: answer.text,
             })),

--- a/src/components/interactive-builder/add-question.modal.tsx
+++ b/src/components/interactive-builder/add-question.modal.tsx
@@ -215,8 +215,13 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
     setConceptAnsToLookup('');
     setSelectedAnsConcept(concept);
     const newAnswer = { id: concept.uuid, text: concept.display };
-    setaddedAnswers((prevAnswers) => [...prevAnswers, newAnswer]);
+    const answerExistsInSelected = selectedAnswers.some((answer) => answer.id === newAnswer.id);
+    const answerExistsInAdded = addedAnswers.some((answer) => answer.id === newAnswer.id);
+    if (!answerExistsInSelected && !answerExistsInAdded) {
+      setaddedAnswers((prevAnswers) => [...prevAnswers, newAnswer]);
+    }
   };
+
   const handlePersonAttributeTypeChange = ({ selectedItem }: { selectedItem: PersonAttributeType }) => {
     setSelectedPersonAttributeType(selectedItem);
   };

--- a/src/components/interactive-builder/add-question.modal.tsx
+++ b/src/components/interactive-builder/add-question.modal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useTranslation, type TFunction } from 'react-i18next';
 import flattenDeep from 'lodash-es/flattenDeep';
 import {
@@ -140,7 +140,6 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
   const [addInlineDate, setAddInlineDate] = useState(false);
   const [selectedProgramState, setSelectedProgramState] = useState<Array<ProgramState>>([]);
   const [selectedProgram, setSelectedProgram] = useState<Program>(null);
-  const [isCreatingQuestion, setIsCreatingQuestion] = useState(false);
   const [programWorkflow, setProgramWorkflow] = useState<ProgramWorkflow>(null);
   const { programs, programsLookupError, isLoadingPrograms } = usePrograms();
   const { programStates, programStatesLookupError, isLoadingProgramStates, mutateProgramStates } = useProgramWorkStates(
@@ -198,7 +197,7 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
     );
   };
   const handleDeleteAnswer = (id) => {
-    setaddedAnswers((prevAnswers) => prevAnswers.filter((answer) => answer.id !== id));
+    setAddedAnswers((prevAnswers) => prevAnswers.filter((answer) => answer.id !== id));
   };
   const handleSaveMoreAnswers = () => {
     const newAnswers = addedAnswers.filter(
@@ -207,8 +206,8 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
 
     const updatedAnswers = [...selectedAnswers, ...newAnswers];
     setSelectedAnswers(updatedAnswers);
-    setaddedAnswers([]);
-    setIsCreatingQuestion(true);
+    setAddedAnswers([]);
+    return updatedAnswers;
   };
 
   const handleConceptAnsSelect = (concept: Concept) => {
@@ -218,7 +217,7 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
     const answerExistsInSelected = selectedAnswers.some((answer) => answer.id === newAnswer.id);
     const answerExistsInAdded = addedAnswers.some((answer) => answer.id === newAnswer.id);
     if (!answerExistsInSelected && !answerExistsInAdded) {
-      setaddedAnswers((prevAnswers) => [...prevAnswers, newAnswer]);
+      setAddedAnswers((prevAnswers) => [...prevAnswers, newAnswer]);
     }
   };
 
@@ -241,13 +240,13 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
     const questionIds: Array<string> = flattenDeep(nestedIds);
     return questionIds.includes(idToTest);
   };
-
   const handleCreateQuestion = () => {
-    handleSaveMoreAnswers();
+    const updatedAnswers = handleSaveMoreAnswers();
+    createQuestion(updatedAnswers);
     closeModal();
   };
 
-  const createQuestion = useCallback(() => {
+  const createQuestion = (selectedAnswers) => {
     try {
       const questionIndex = schema.pages[pageIndex]?.sections?.[sectionIndex]?.questions?.length ?? 0;
       const computedQuestionId = `question${questionIndex + 1}Section${sectionIndex + 1}Page-${pageIndex + 1}`;
@@ -331,6 +330,7 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
         });
       }
     }
+<<<<<<< HEAD
   }, [
     onSchemaChange,
     t,
@@ -356,6 +356,9 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
     toggleLabelTrue,
     toggleLabelFalse,
   ]);
+=======
+  };
+>>>>>>> 1b94b7b (removed callback)
 
   const convertLabelToCamelCase = () => {
     const camelCasedLabel = questionLabel
@@ -384,12 +387,6 @@ const AddQuestionModal: React.FC<AddQuestionModalProps> = ({
     setSelectedProgram(selectedItem);
     setProgramWorkflows(selectedItem?.allWorkflows);
   };
-  useEffect(() => {
-    if (isCreatingQuestion) {
-      createQuestion();
-      setIsCreatingQuestion(false);
-    }
-  }, [isCreatingQuestion, createQuestion]);
 
   return (
     <>

--- a/src/components/interactive-builder/edit-question.modal.tsx
+++ b/src/components/interactive-builder/edit-question.modal.tsx
@@ -239,7 +239,11 @@ const EditQuestionModal: React.FC<EditQuestionModalProps> = ({
     setConceptAnsToLookup('');
     setSelectedAnsConcept(concept);
     const newAnswer = { id: concept.uuid, text: concept.display };
-    setaddedAnswers((prevAnswers) => [...prevAnswers, newAnswer]);
+    const answerExistsInSelected = selectedAnswers.some((answer) => answer.id === newAnswer.id);
+    const answerExistsInAdded = addedAnswers.some((answer) => answer.id === newAnswer.id);
+    if (!answerExistsInSelected && !answerExistsInAdded) {
+      setaddedAnswers((prevAnswers) => [...prevAnswers, newAnswer]);
+    }
   };
   const showAddQuestion = () => {
     if (!addAnswer) {

--- a/src/components/interactive-builder/edit-question.modal.tsx
+++ b/src/components/interactive-builder/edit-question.modal.tsx
@@ -913,7 +913,7 @@ const EditQuestionModal: React.FC<EditQuestionModalProps> = ({
                       </div>
                     ) : null}
 
-                    {!hasConceptChanged && editConceptInfo?.datatype?.uuid == '8d4a48b6-c2cc-11de-8d13-0010c6dffd0f' ? (
+                    {!hasConceptChanged && editConceptInfo?.datatype?.display == 'Coded' ? (
                       <div>
                         <Button kind="tertiary" onClick={showAddQuestion} iconDescription="Add" size="sm">
                           More Answers

--- a/src/components/interactive-builder/edit-question.modal.tsx
+++ b/src/components/interactive-builder/edit-question.modal.tsx
@@ -44,6 +44,7 @@ import type {
   DatePickerTypeOption,
 } from '../../types';
 import { useConceptLookup } from '../../hooks/useConceptLookup';
+import { useConceptInfo } from '../../hooks/useConceptInfo';
 import { useConceptName } from '../../hooks/useConceptName';
 import { usePatientIdentifierLookup } from '../../hooks/usePatientIdentifierLookup';
 import { usePatientIdentifierName } from '../../hooks/usePatientIdentifierName';
@@ -129,7 +130,7 @@ const EditQuestionModal: React.FC<EditQuestionModalProps> = ({
     isLoadingConcepts: isLoadingAnsConcepts,
   } = useConceptLookup(conceptAnsToLookup);
   const [selectedConcept, setSelectedConcept] = useState<Concept | null>(null);
-
+  const { concept: editConceptInfo } = useConceptInfo(questionToEdit.questionOptions.concept);
   const { concepts, isLoadingConcepts } = useConceptLookup(conceptToLookup);
   const { conceptName, conceptNameLookupError, isLoadingConceptName } = useConceptName(
     questionToEdit.questionOptions.concept,
@@ -170,7 +171,6 @@ const EditQuestionModal: React.FC<EditQuestionModalProps> = ({
     date: [{ value: 'calendar', label: t('calendarOnly', 'Calendar only'), defaultChecked: false }],
     time: [{ value: 'timer', label: t('timerOnly', 'Timer only'), defaultChecked: false }],
   };
-
   const debouncedSearch = useMemo(() => {
     return debounce((searchTerm: string) => setConceptToLookup(searchTerm), 500) as (searchTerm: string) => void;
   }, []);
@@ -202,6 +202,7 @@ const EditQuestionModal: React.FC<EditQuestionModalProps> = ({
     setAnswer(false);
     setConceptToLookup('');
     setSelectedAnswers([]);
+    setAddedAnswers([]);
     setSelectedConcept(concept);
     setConceptMappings(
       concept?.mappings?.map((conceptMapping) => {
@@ -912,7 +913,14 @@ const EditQuestionModal: React.FC<EditQuestionModalProps> = ({
                       </div>
                     ) : null}
 
-                    {(selectedConcept || questionToEdit) && questionToEdit?.questionOptions.answers?.length ? (
+                    {!hasConceptChanged && editConceptInfo?.datatype?.uuid == '8d4a48b6-c2cc-11de-8d13-0010c6dffd0f' ? (
+                      <div>
+                        <Button kind="tertiary" onClick={showAddQuestion} iconDescription="Add" size="sm">
+                          More Answers
+                        </Button>
+                      </div>
+                    ) : null}
+                    {hasConceptChanged && answersFromConcept.length ? (
                       <div>
                         <Button kind="tertiary" onClick={showAddQuestion} iconDescription="Add" size="sm">
                           More Answers

--- a/src/components/interactive-builder/edit-question.modal.tsx
+++ b/src/components/interactive-builder/edit-question.modal.tsx
@@ -286,20 +286,20 @@ const EditQuestionModal: React.FC<EditQuestionModalProps> = ({
     setProgramWorkflows(selectedItem?.allWorkflows);
   };
 
-  const updateQuestion = (questionIndex: number, selectedAnswers) => {
+  const updateQuestion = (questionIndex: number, updatedAnswers) => {
     let mappedAnswers = [];
 
     // update changed concept based on details
-    if (!hasConceptChanged && selectedAnswers?.length) {
-      mappedAnswers = selectedAnswers.map((answer) => ({
+    if (!hasConceptChanged && updatedAnswers?.length) {
+      mappedAnswers = updatedAnswers.map((answer) => ({
         concept: answer.id,
         label: answer.text,
       }));
     } else if (hasConceptChanged && answersFromConcept.length === 0) {
       mappedAnswers = [];
-    } else if (hasConceptChanged && answersFromConcept?.length > 0 && selectedAnswers?.length) {
-      mappedAnswers = selectedAnswers?.length
-        ? selectedAnswers.map((answer) => ({
+    } else if (hasConceptChanged && answersFromConcept?.length > 0 && updatedAnswers?.length) {
+      mappedAnswers = updatedAnswers?.length
+        ? updatedAnswers.map((answer) => ({
             concept: answer.id,
             label: answer.text,
           }))

--- a/src/components/interactive-builder/question-modal.scss
+++ b/src/components/interactive-builder/question-modal.scss
@@ -155,3 +155,14 @@
     }
   }
 }
+.conceptAnswer{
+  display: flex;
+  flex-direction: row;
+  gap: 3%; 
+  justify-content: center;
+  align-items: center;
+}
+.conceptAnswer > *:first-child {
+  margin-right: 0;
+  width:90%
+}

--- a/src/components/interactive-builder/question-modal.scss
+++ b/src/components/interactive-builder/question-modal.scss
@@ -155,14 +155,10 @@
     }
   }
 }
-.conceptAnswer{
-  display: flex;
-  flex-direction: row;
-  gap: 3%; 
-  justify-content: center;
-  align-items: center;
-}
-.conceptAnswer > *:first-child {
-  margin-right: 0;
-  width:90%
+.conceptAnswerButton {
+  margin-left: 5px;
+  color: black;
+  background: none; 
+  border: none;     
+  padding: 0;      
 }

--- a/src/hooks/useConceptInfo.ts
+++ b/src/hooks/useConceptInfo.ts
@@ -1,0 +1,13 @@
+import useSWR from 'swr';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
+import type { Concept } from '../types';
+
+export function useConceptInfo(conceptId: string) {
+  const url = `${restBaseUrl}/concept/${conceptId}`;
+
+  const { data } = useSWR<{ data: Concept }, Error>(conceptId ? url : null, openmrsFetch);
+
+  return {
+    concept: data?.data ?? null,
+  };
+}

--- a/translations/en.json
+++ b/translations/en.json
@@ -192,7 +192,7 @@
   "schemaNotFoundText": "The schema originally associated with this form could not be found. A draft schema was found saved in your browser's local storage. Would you like to load it instead?",
   "schemaSaveWarningMessage": "The dev3 server is ephemeral at best and can't be relied upon to save your schemas permanently. To avoid losing your work, please save your schemas to your local machine. Alternatively, upload your schema to the distro repo to have it persisted across server resets.",
   "searchConcept": "Search using a concept name or UUID",
-  "searchForAnswerConcept": "Search for an answer Concept to Add",
+  "searchForAnswerConcept": "Search for a concept to add as an answer",
   "searchForBackingConcept": "Search for a backing concept",
   "searchForBackingPatientIdentifierType": "Search for a backing patient identifier type",
   "searchForBackingPersonAttributeType": "Search for a backing person attribute type",

--- a/translations/en.json
+++ b/translations/en.json
@@ -192,6 +192,7 @@
   "schemaNotFoundText": "The schema originally associated with this form could not be found. A draft schema was found saved in your browser's local storage. Would you like to load it instead?",
   "schemaSaveWarningMessage": "The dev3 server is ephemeral at best and can't be relied upon to save your schemas permanently. To avoid losing your work, please save your schemas to your local machine. Alternatively, upload your schema to the distro repo to have it persisted across server resets.",
   "searchConcept": "Search using a concept name or UUID",
+  "searchForAnswerConcept": "Search for an answer Concept to Add",
   "searchForBackingConcept": "Search for a backing concept",
   "searchForBackingPatientIdentifierType": "Search for a backing patient identifier type",
   "searchForBackingPersonAttributeType": "Search for a backing person attribute type",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2830,13 +2830,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/resolve-uri@npm:3.1.0":
-  version: 3.1.0
-  resolution: "@jridgewell/resolve-uri@npm:3.1.0"
-  checksum: 10/320ceb37af56953757b28e5b90c34556157676d41e3d0a3ff88769274d62373582bb0f0276a4f2d29c3f4fdd55b82b8be5731f52d391ad2ecae9b321ee1c742d
-  languageName: node
-  linkType: hard
-
 "@jridgewell/resolve-uri@npm:^3.1.0":
   version: 3.1.2
   resolution: "@jridgewell/resolve-uri@npm:3.1.2"
@@ -2861,13 +2854,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:1.4.14":
-  version: 1.4.14
-  resolution: "@jridgewell/sourcemap-codec@npm:1.4.14"
-  checksum: 10/26e768fae6045481a983e48aa23d8fcd23af5da70ebd74b0649000e815e7fbb01ea2bc088c9176b3fffeb9bec02184e58f46125ef3320b30eaa1f4094cfefa38
-  languageName: node
-  linkType: hard
-
 "@jridgewell/sourcemap-codec@npm:^1.4.10":
   version: 1.5.0
   resolution: "@jridgewell/sourcemap-codec@npm:1.5.0"
@@ -2882,13 +2868,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/trace-mapping@npm:^0.3.12":
-  version: 0.3.17
-  resolution: "@jridgewell/trace-mapping@npm:0.3.17"
+"@jridgewell/trace-mapping@npm:^0.3.12, @jridgewell/trace-mapping@npm:^0.3.20, @jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.25":
+  version: 0.3.25
+  resolution: "@jridgewell/trace-mapping@npm:0.3.25"
   dependencies:
-    "@jridgewell/resolve-uri": "npm:3.1.0"
-    "@jridgewell/sourcemap-codec": "npm:1.4.14"
-  checksum: 10/790d439c9b271d9fc381dc4a837393ab942920245efedd5db20f65a665c0f778637fa623573337d3241ff784ffdb6724bbadf7fa2b61666bcd4884064b02f113
+    "@jridgewell/resolve-uri": "npm:^3.1.0"
+    "@jridgewell/sourcemap-codec": "npm:^1.4.14"
+  checksum: 10/dced32160a44b49d531b80a4a2159dceab6b3ddf0c8e95a0deae4b0e894b172defa63d5ac52a19c2068e1fe7d31ea4ba931fbeec103233ecb4208953967120fc
   languageName: node
   linkType: hard
 
@@ -2899,16 +2885,6 @@ __metadata:
     "@jridgewell/resolve-uri": "npm:^3.1.0"
     "@jridgewell/sourcemap-codec": "npm:^1.4.14"
   checksum: 10/06a2a4e26e3cc369c41144fad7cbee29ba9ea6aca85acc565ec8f2110e298fdbf93986e17da815afae94539dcc03115cdbdbb575d3bea356e167da6987531e4d
-  languageName: node
-  linkType: hard
-
-"@jridgewell/trace-mapping@npm:^0.3.20, @jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.25":
-  version: 0.3.25
-  resolution: "@jridgewell/trace-mapping@npm:0.3.25"
-  dependencies:
-    "@jridgewell/resolve-uri": "npm:^3.1.0"
-    "@jridgewell/sourcemap-codec": "npm:^1.4.14"
-  checksum: 10/dced32160a44b49d531b80a4a2159dceab6b3ddf0c8e95a0deae4b0e894b172defa63d5ac52a19c2068e1fe7d31ea4ba931fbeec103233ecb4208953967120fc
   languageName: node
   linkType: hard
 
@@ -15299,15 +15275,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.4":
-  version: 3.3.4
-  resolution: "nanoid@npm:3.3.4"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: 10/4f01aaf742452d8668d1d99a21218eb9eaa703c0291e7ec5bbb17a7c0ac56df3b791723ce4d429f53949b252e1ce26386a0aa6782fce10d44cd617d89c9fe9d2
-  languageName: node
-  linkType: hard
-
 "nanoid@npm:^3.3.7":
   version: 3.3.7
   resolution: "nanoid@npm:3.3.7"
@@ -16719,18 +16686,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.2.15":
-  version: 8.4.19
-  resolution: "postcss@npm:8.4.19"
-  dependencies:
-    nanoid: "npm:^3.3.4"
-    picocolors: "npm:^1.0.0"
-    source-map-js: "npm:^1.0.2"
-  checksum: 10/33d5dc0919e6f4ffa2da8f5ca990b5ce83c0316b5714695ede57434253a88c13c959ef76f026a60ec33740ba1de87968f6b0c05dec9e81d8d9f2fbb2872a42e9
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.4.33, postcss@npm:^8.4.41":
+"postcss@npm:^8.2.15, postcss@npm:^8.4.33, postcss@npm:^8.4.41":
   version: 8.4.47
   resolution: "postcss@npm:8.4.47"
   dependencies:
@@ -18475,13 +18431,6 @@ __metadata:
   version: 1.2.1
   resolution: "source-map-js@npm:1.2.1"
   checksum: 10/ff9d8c8bf096d534a5b7707e0382ef827b4dd360a577d3f34d2b9f48e12c9d230b5747974ee7c607f0df65113732711bb701fe9ece3c7edbd43cb2294d707df3
-  languageName: node
-  linkType: hard
-
-"source-map-js@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "source-map-js@npm:1.0.2"
-  checksum: 10/38e2d2dd18d2e331522001fc51b54127ef4a5d473f53b1349c5cca2123562400e0986648b52e9407e348eaaed53bce49248b6e2641e6d793ca57cb2c360d6d51
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
Users are now be able to manually add specific concepts as answers to a concept of type Coded after searching of them (similar to how we add a backing concept)
## Screenshots
![BeforeClick](https://github.com/user-attachments/assets/4256615f-bc87-4191-aac6-fadc9f7c8b9a)

![AfterClick](https://github.com/user-attachments/assets/b5aaf5dd-2617-44cf-a565-a890a42e64bc)
![select answer 1](https://github.com/user-attachments/assets/063f59ac-c697-4551-b8c8-a86e67c1e141)
![select Ans 2](https://github.com/user-attachments/assets/cbed8016-82b9-41fe-b41f-244e5a8aa90a)
![selected ans 3](https://github.com/user-attachments/assets/9e705606-b948-41de-83c3-1de143f292bd)
![select ans 4](https://github.com/user-attachments/assets/06377ce2-5f39-4334-ba65-de75f42cc207)
![select ans 5](https://github.com/user-attachments/assets/1ebff127-507d-4949-a509-19aaa9dd8c8d)

## Related Issue


https://openmrs.atlassian.net/browse/O3-3712
## Other
<!-- Anything not covered above -->
