### PR TITLE
(chore) Form builder should use the latest form-engine-lib versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "coverage": "yarn test --coverage --passWithNoTests",
     "postinstall": "husky install",
     "extract-translations": "i18next 'src/**/*.component.tsx' 'src/**/*.modal.tsx' --config ./i18next-parser.config.js",
-    "ci:bump-form-engine-lib": "yarn up @openmrs/esm-form-engine-lib@next"
+    "ci:bump-form-engine-lib": "yarn up @openmrs/esm-form-engine-lib@latest"
   },
   "files": [
     "dist",
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@carbon/react": "~1.49.0",
-    "@openmrs/esm-form-engine-lib": "next",
+    "@openmrs/esm-form-engine-lib": "latest",
     "ajv": "^8.17.1",
     "dotenv": "^16.4.5",
     "file-loader": "^6.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3426,7 +3426,7 @@ __metadata:
     "@dnd-kit/modifiers": "npm:^6.0.1"
     "@dnd-kit/sortable": "npm:^7.0.2"
     "@dnd-kit/utilities": "npm:^3.2.2"
-    "@openmrs/esm-form-engine-lib": "npm:next"
+    "@openmrs/esm-form-engine-lib": "npm:latest"
     "@openmrs/esm-framework": "npm:next"
     "@openmrs/esm-patient-common-lib": "npm:next"
     "@openmrs/esm-styleguide": "npm:next"
@@ -3489,9 +3489,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-form-engine-lib@npm:next":
-  version: 3.1.0-pre.1684
-  resolution: "@openmrs/esm-form-engine-lib@npm:3.1.0-pre.1684"
+"@openmrs/esm-form-engine-lib@npm:latest":
+  version: 3.1.1
+  resolution: "@openmrs/esm-form-engine-lib@npm:3.1.1"
   dependencies:
     "@carbon/react": "npm:>1.47.0 <1.50.0"
     classnames: "npm:^2.5.1"
@@ -3509,7 +3509,7 @@ __metadata:
     react: 18.x
     react-i18next: 11.x
     swr: 2.x
-  checksum: 10/f25c7699c06cfb547954704c624089aa726858620a26b1a383afee95eada26836e348fb4fef2cb7c62f8f461e6d9832ff8f44bf5e0e269336c36ce172edfe547
+  checksum: 10/afb11bbcf73bffce13ff83b4a76d7af8a24031a699e7c33c4f763ba1b57ccd45b608a95f8f072117da4721bd927deb740d20b94b210cdeb4c6ffd218d9b209c3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
The form builder app should use the `latest` (not `next`) released form-engine-lib versions.

## Screenshots
None

## Related Issue
None

## Other
<!-- Anything not covered above -->
