### PR TITLE
 Made changes to prevent the defaulting of the value to Null

### DIFF
--- a/src/components/interactive-builder/edit-question.modal.tsx
+++ b/src/components/interactive-builder/edit-question.modal.tsx
@@ -418,6 +418,10 @@ const EditQuestionModal: React.FC<EditQuestionModalProps> = ({
   }, [programWorkflow, questionToEdit.questionOptions.answers]);
 
   useEffect(() => {
+    setQuestionLabel(questionToEdit.label);
+  }, [questionToEdit.label]);
+
+  useEffect(() => {
     if (questionToEdit?.questionOptions?.answers) {
       const initialAnswers = questionToEdit.questionOptions.answers.map((answer) => ({
         id: answer.concept,


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
The edit question form has an issue with the question label as it resets to null value if it is not modifying when editing it.




## Screenshots
<!-- Required if you are making UI changes. -->
Before:

https://github.com/user-attachments/assets/ff94f8f1-3fd2-472e-9255-0a27722adb12

After:


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
