### PR TITLE
(fix) O3-4424: Fix Context Provider State Merge for Obs Group Questions

### DIFF
--- a/src/components/interactive-builder/modals/question/form-field-context.tsx
+++ b/src/components/interactive-builder/modals/question/form-field-context.tsx
@@ -23,16 +23,42 @@ export const FormFieldProvider: React.FC<{
   const updateObsGroupedQuestion = useCallback(
     (updatedObsGroupFormField: FormField) => {
       setFormField((prevFormField) => {
-        const formFieldCopy = { ...prevFormField };
-        if (formFieldCopy.questions) {
-          if (formFieldCopy.questions?.length === 1 && formFieldCopy.questions[0].id === '') {
-            formFieldCopy.questions[0] = updatedObsGroupFormField;
-          } else {
-            formFieldCopy.questions.pop();
-            formFieldCopy.questions.push(updatedObsGroupFormField);
-          }
+        let newFormField = { ...prevFormField, ...updatedObsGroupFormField };
+
+        if (!prevFormField.questions) {
+          newFormField.questions = [updatedObsGroupFormField];
+          return newFormField;
         }
-        return formFieldCopy;
+
+        const placeholderIndex = prevFormField.questions.findIndex((q) => q.id === '');
+        if (placeholderIndex !== -1) {
+          const updatedQuestions = [...prevFormField.questions];
+          updatedQuestions[placeholderIndex] = {
+            ...updatedQuestions[placeholderIndex],
+            ...updatedObsGroupFormField,
+          };
+          newFormField.questions = updatedQuestions;
+          return newFormField;
+        }
+
+        const matchIndex = prevFormField.questions.findIndex((q) => q.id === updatedObsGroupFormField.id);
+        if (matchIndex !== -1) {
+          const updatedQuestions = [...prevFormField.questions];
+          updatedQuestions[matchIndex] = {
+            ...updatedQuestions[matchIndex],
+            ...updatedObsGroupFormField,
+          };
+          newFormField.questions = updatedQuestions;
+          return newFormField;
+        }
+
+        const updatedQuestions = [...prevFormField.questions];
+        updatedQuestions[updatedQuestions.length - 1] = {
+          ...updatedQuestions[updatedQuestions.length - 1],
+          ...updatedObsGroupFormField,
+        };
+        newFormField.questions = updatedQuestions;
+        return newFormField;
       });
     },
     [setFormField],
@@ -40,7 +66,12 @@ export const FormFieldProvider: React.FC<{
 
   return (
     <FormFieldContext.Provider
-      value={{ formField, setFormField: isObsGrouped ? updateObsGroupedQuestion : setFormField, concept, setConcept }}
+      value={{
+        formField,
+        setFormField: isObsGrouped ? updateObsGroupedQuestion : setFormField,
+        concept,
+        setConcept,
+      }}
     >
       {children}
     </FormFieldContext.Provider>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR addresses an issue with editing obs group questions where changes to the Unique ID and Question Type fields were not persisting. The problem was traced to the context provider, which did not merge updates properly into both the top-level form field state and its nested questions array.

In this update, the FormFieldContext provider is modified so that when a subquestion is updated, its changes are merged into the main form field as well as into the corresponding entry in the questions array. This ensures that users can successfully edit the Unique ID and Question Type fields without the input resetting or only accepting a single character.

## Screenshots
<!-- Required if you are making UI changes. -->
Before

https://github.com/user-attachments/assets/37b6792c-e800-4c33-9ba5-fe7a6ebb06ee

After

https://github.com/user-attachments/assets/01764392-16ef-4ad9-b28f-42b30eef6748



## Related Issue
https://openmrs.atlassian.net/browse/O3-4424

<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
