### PR TITLE
(feat) O3-4318: Allow deleting sub questions of obsGroup type questions

### DIFF
--- a/src/components/interactive-builder/modals/question/question.modal.tsx
+++ b/src/components/interactive-builder/modals/question/question.modal.tsx
@@ -64,7 +64,7 @@ const QuestionModalContent: React.FC<QuestionModalProps> = ({
     const emptyQuestion: FormField = {
       type: '',
       questionOptions: undefined,
-      id: '', // new question without an id initially
+      id: '',
     };
     setFormField((prevFormField) => ({
       ...prevFormField,
@@ -72,12 +72,11 @@ const QuestionModalContent: React.FC<QuestionModalProps> = ({
     }));
   }, [setFormField]);
 
-  // Updated deletion: filter out the question by its id.
   const deleteObsGroupQuestion = useCallback(
-    (id: string) => {
+    (index: number) => {
       setFormField((prevFormField) => ({
         ...prevFormField,
-        questions: prevFormField.questions?.filter((q) => q.id !== id) || [],
+        questions: prevFormField.questions?.filter((_, i) => i !== index) || [],
       }));
     },
     [setFormField],
@@ -140,9 +139,9 @@ const QuestionModalContent: React.FC<QuestionModalProps> = ({
                 <Accordion size="lg">
                   {formField.questions.map((question, index) => (
                     <AccordionItem
-                      key={question.id || index}
+                      key={question.id || `Question ${index + 1}`}
                       title={question.label ?? `Question ${index + 1}`}
-                      open={index === formField.questions.length - 1}
+                      open={index === formField.questions?.length - 1}
                       className={styles.obsGroupQuestionContent}
                     >
                       <FormFieldProvider
@@ -155,10 +154,10 @@ const QuestionModalContent: React.FC<QuestionModalProps> = ({
                         <Question checkIfQuestionIdExists={checkIfQuestionIdExists} />
                         <Button
                           kind="danger"
-                          onClick={() => deleteObsGroupQuestion(question.id)}
+                          onClick={() => deleteObsGroupQuestion(index)}
                           className={styles.deleteObsGroupQuestionButton}
                         >
-                          {t('deleteQuestion', 'Delete')}
+                          {t('deleteQuestion', 'Delete question')}
                         </Button>
                       </FormFieldProvider>
                     </AccordionItem>

--- a/src/components/interactive-builder/modals/question/question.modal.tsx
+++ b/src/components/interactive-builder/modals/question/question.modal.tsx
@@ -64,13 +64,24 @@ const QuestionModalContent: React.FC<QuestionModalProps> = ({
     const emptyQuestion: FormField = {
       type: '',
       questionOptions: undefined,
-      id: '',
+      id: '', // new question without an id initially
     };
     setFormField((prevFormField) => ({
       ...prevFormField,
       questions: prevFormField.questions ? [...prevFormField.questions, emptyQuestion] : [emptyQuestion],
     }));
   }, [setFormField]);
+
+  // Updated deletion: filter out the question by its id.
+  const deleteObsGroupQuestion = useCallback(
+    (id: string) => {
+      setFormField((prevFormField) => ({
+        ...prevFormField,
+        questions: prevFormField.questions?.filter((q) => q.id !== id) || [],
+      }));
+    },
+    [setFormField],
+  );
 
   const saveQuestion = () => {
     try {
@@ -129,7 +140,7 @@ const QuestionModalContent: React.FC<QuestionModalProps> = ({
                 <Accordion size="lg">
                   {formField.questions.map((question, index) => (
                     <AccordionItem
-                      key={index}
+                      key={question.id || index}
                       title={question.label ?? `Question ${index + 1}`}
                       open={index === formField.questions.length - 1}
                       className={styles.obsGroupQuestionContent}
@@ -142,6 +153,13 @@ const QuestionModalContent: React.FC<QuestionModalProps> = ({
                         }
                       >
                         <Question checkIfQuestionIdExists={checkIfQuestionIdExists} />
+                        <Button
+                          kind="danger"
+                          onClick={() => deleteObsGroupQuestion(question.id)}
+                          className={styles.deleteObsGroupQuestionButton}
+                        >
+                          {t('deleteQuestion', 'Delete')}
+                        </Button>
                       </FormFieldProvider>
                     </AccordionItem>
                   ))}

--- a/src/components/interactive-builder/modals/question/question.scss
+++ b/src/components/interactive-builder/modals/question/question.scss
@@ -37,3 +37,7 @@
     padding-right: 0%;
   }
 }
+
+.deleteObsGroupQuestionButton {
+  margin-top: 1rem;
+}

--- a/src/components/interactive-builder/modals/question/question.scss
+++ b/src/components/interactive-builder/modals/question/question.scss
@@ -39,5 +39,5 @@
 }
 
 .deleteObsGroupQuestionButton {
-  margin-top: 1rem;
+  margin-top: layout.$spacing-05;
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR adds a deletion feature for sub questions within obsGroup type questions—a functionality that was previously absent. Users can now delete individual sub questions by clicking the delete button associated with each sub question. The implementation uses each sub question’s unique identifier (with a fallback when necessary) to ensure the correct item is removed from the parent’s questions array. This enhancement improves the form builder’s usability by enabling more precise management of grouped questions.

## Screenshots
<!-- Required if you are making UI changes. -->

https://github.com/user-attachments/assets/0a0e3365-48d7-4c0e-9947-a40615d24a72



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4318

## Other
<!-- Anything not covered above -->
