### PR TITLE
(fix) O3-4442: Duplicate Subquestion IDs in ObsGroup should trigger validation

### DIFF
--- a/src/components/interactive-builder/modals/question/question-form/question/question.component.tsx
+++ b/src/components/interactive-builder/modals/question/question-form/question/question.component.tsx
@@ -35,7 +35,7 @@ const Question: React.FC<QuestionProps> = ({ checkIfQuestionIdExists }) => {
     <>
       <TextInput
         id="questionId"
-        invalid={formField?.id ? isQuestionIdValid() : false}
+        invalid={!!formField?.id && isQuestionIdValid()}
         invalidText={t('questionIdExists', 'This question ID already exists in your schema')}
         labelText={
           <div className={styles.questionIdLabel}>

--- a/src/components/interactive-builder/modals/question/question-form/question/question.component.tsx
+++ b/src/components/interactive-builder/modals/question/question-form/question/question.component.tsx
@@ -27,7 +27,7 @@ const Question: React.FC<QuestionProps> = ({ checkIfQuestionIdExists }) => {
     setFormField({ ...formField, id: camelCasedLabel });
   };
 
-  const isQuestionIdValid = useCallback(() => {
+  const isQuestionIdDuplicate = useCallback(() => {
     return checkIfQuestionIdExists(formField.id);
   }, [formField.id, checkIfQuestionIdExists]);
 
@@ -35,7 +35,7 @@ const Question: React.FC<QuestionProps> = ({ checkIfQuestionIdExists }) => {
     <>
       <TextInput
         id="questionId"
-        invalid={!!formField?.id && isQuestionIdValid()}
+        invalid={!!formField?.id && isQuestionIdDuplicate()}
         invalidText={t('questionIdExists', 'This question ID already exists in your schema')}
         labelText={
           <div className={styles.questionIdLabel}>

--- a/src/components/interactive-builder/modals/question/question.modal.tsx
+++ b/src/components/interactive-builder/modals/question/question.modal.tsx
@@ -57,13 +57,16 @@ const QuestionModalContent: React.FC<QuestionModalProps> = ({
       const formFieldIds: string[] = formField?.questions ? getAllQuestionIds(formField.questions) : [];
 
       // Combine both arrays, along with the parent question ID and count occurrences of the ID
-      const allIds = [...schemaIds, ...formFieldIds, formField.id];
+      const allIds = [...schemaIds, ...formFieldIds];
+      if (!formFieldProp || formFieldProp.id !== formField.id) {
+        allIds.push(formField.id);
+      }
       const occurrences = allIds.filter((id) => id === idToTest).length;
 
       // Return true if ID occurs more than once
       return occurrences > 1;
     },
-    [schema, getAllQuestionIds, formField],
+    [schema, getAllQuestionIds, formField, formFieldProp],
   );
 
   const addObsGroupQuestion = useCallback(() => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR resolves the issue where subquestions in obsGroups could share duplicate IDs by implementing a sibling-based duplicate check.I updated the duplicate-check logic in the QuestionModal so that subquestions now validate their IDs against their sibling entries rather than the entire schema, ensuring local uniqueness before saving, while maintaining the recursive check for main questions.

## Screenshots
<!-- Required if you are making UI changes. -->

https://github.com/user-attachments/assets/6722d567-abd1-4110-a9e4-958b98f76e35



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4442

## Other
<!-- Anything not covered above -->
