### PR TITLE
(fix) O3-4489: obsGroup child question id gets flagged as duplicate

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3578,7 +3578,7 @@ __metadata:
     "@dnd-kit/utilities": "npm:^3.2.2"
     "@openmrs/esm-form-engine-lib": "npm:latest"
     "@openmrs/esm-framework": "npm:next"
-    "@openmrs/esm-patient-common-lib": "npm:next"
+    "@openmrs/esm-patient-common-lib": "npm:^9.2.1"
     "@openmrs/esm-styleguide": "npm:next"
     "@playwright/test": "npm:^1.50.1"
     "@swc/cli": "npm:^0.1.65"
@@ -3737,9 +3737,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openmrs/esm-patient-common-lib@npm:next":
-  version: 9.2.1-pre.6870
-  resolution: "@openmrs/esm-patient-common-lib@npm:9.2.1-pre.6870"
+"@openmrs/esm-patient-common-lib@npm:^9.2.1":
+  version: 9.2.1
+  resolution: "@openmrs/esm-patient-common-lib@npm:9.2.1"
   dependencies:
     "@carbon/react": "npm:^1.12.0"
     lodash-es: "npm:^4.17.21"
@@ -3748,7 +3748,7 @@ __metadata:
     "@openmrs/esm-framework": 6.x
     react: 18.x
     single-spa: 6.x
-  checksum: 10/0891a1c2b020d16c5dc57c69dd58bbcaac1ef081686a038a16a3b3fc18abe71b03fb26360b39dd421c862d7ec3f63ec70e4ccf0b08fc726a29188f55c6f6ec26
+  checksum: 10/c29f30cfb75b13692c0e0ad93d17a826a077f017b6f3d6d1896554a7992f25e88953b4a4c83fc61bb46318d2dddd42ce774a654aa00a89cd07a3f09a535e0d9e
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3578,7 +3578,7 @@ __metadata:
     "@dnd-kit/utilities": "npm:^3.2.2"
     "@openmrs/esm-form-engine-lib": "npm:latest"
     "@openmrs/esm-framework": "npm:next"
-    "@openmrs/esm-patient-common-lib": "npm:^9.2.1"
+    "@openmrs/esm-patient-common-lib": "npm:next"
     "@openmrs/esm-styleguide": "npm:next"
     "@playwright/test": "npm:^1.50.1"
     "@swc/cli": "npm:^0.1.65"
@@ -3737,9 +3737,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openmrs/esm-patient-common-lib@npm:^9.2.1":
-  version: 9.2.1
-  resolution: "@openmrs/esm-patient-common-lib@npm:9.2.1"
+"@openmrs/esm-patient-common-lib@npm:next":
+  version: 9.2.2-pre.6922
+  resolution: "@openmrs/esm-patient-common-lib@npm:9.2.2-pre.6922"
   dependencies:
     "@carbon/react": "npm:^1.12.0"
     lodash-es: "npm:^4.17.21"
@@ -3748,7 +3748,7 @@ __metadata:
     "@openmrs/esm-framework": 6.x
     react: 18.x
     single-spa: 6.x
-  checksum: 10/c29f30cfb75b13692c0e0ad93d17a826a077f017b6f3d6d1896554a7992f25e88953b4a4c83fc61bb46318d2dddd42ce774a654aa00a89cd07a3f09a535e0d9e
+  checksum: 10/41001b0beba68c277b2013bd6457dc3c742436f188fec23ae3ea395bca3802c6aae725eac783a00110c434100615c1f41a7348b01a7789ded180d75bbb459d18
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR fixes an issue where when you try to edit an obsGroup question the child questions ids gets marked as duplicate, even when they are not. This was because of an error in the code that added the id twice to an array.

## Screenshots
<!-- Required if you are making UI changes. -->
Before fix:
![image](https://github.com/user-attachments/assets/adb57ad2-0dab-47fd-8ca7-7e34f08c1441)

After fix:
<img width="830" alt="Screenshot 2025-02-27 at 5 20 18 PM" src="https://github.com/user-attachments/assets/0a236501-acf4-4365-8f7a-c18f6843cfba" />

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-4489

## Other
<!-- Anything not covered above -->
