### PR TITLE
(fix) O3-4493: Disable save question button when concept is invalid

### DIFF
--- a/e2e/specs/edit-form-with-interactive-builder.spec.ts
+++ b/e2e/specs/edit-form-with-interactive-builder.spec.ts
@@ -63,7 +63,7 @@ test('Edit a form using the interactive builder', async ({ page, context }) => {
                 type: 'obs',
                 questionOptions: {
                   rendering: 'text',
-                  concept: 'a-system-defined-concept-uuid',
+                  concept: '104677AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
                 },
                 id: 'sampleQuestion',
               },

--- a/e2e/specs/edit-form-with-interactive-builder.spec.ts
+++ b/e2e/specs/edit-form-with-interactive-builder.spec.ts
@@ -47,37 +47,6 @@ test.beforeEach(async ({ api }) => {
 
 test('Edit a form using the interactive builder', async ({ page, context }) => {
   const formBuilderPage = new FormBuilderPage(page);
-  const formDetails = {
-    encounterType: 'e22e39fd-7db2-45e7-80f1-60fa0d5a4378',
-    name: 'UI Select Form Test',
-    pages: [
-      {
-        label: 'UI Select Test',
-        sections: [
-          {
-            label: 'Visit Details',
-            isExpanded: 'true',
-            questions: [
-              {
-                label: 'Select Provider',
-                type: 'obs',
-                questionOptions: {
-                  rendering: 'text',
-                  concept: '104677AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-                },
-                id: 'sampleQuestion',
-              },
-            ],
-          },
-        ],
-      },
-    ],
-    processor: 'EncounterFormProcessor',
-    referencedForms: [],
-    uuid: 'xxx',
-    version: '1',
-    description: 'This is test description',
-  };
 
   await test.step('When I visit the form builder', async () => {
     await formBuilderPage.gotoFormBuilder();
@@ -184,11 +153,21 @@ test('Edit a form using the interactive builder', async ({ page, context }) => {
     };
   });
 
+  await test.step('And then I edit the question concept', async () => {
+    await formBuilderPage.conceptSearchInput().fill('Tested for COVID 19');
+    await formBuilderPage.conceptSearchInput().press('Enter');
+    await formBuilderPage.page.getByRole('menuitem', { name: /tested for covid 19/i }).click();
+    updatedForm.pages[0].sections[0].questions[0].questionOptions = {
+      ...updatedForm.pages[0].sections[0].questions[0].questionOptions,
+      concept: '89c5bc03-8ce2-40d8-a77d-20b5a62a1ca1',
+    };
+  });
+
   await test.step('Then I click the `Save` button', async () => {
     await formBuilderPage.saveButton().click();
   });
 
-  await test.step('Then I should get a success message and the question name should be renamed', async () => {
+  await test.step('Then I should get a success message and the question label should be renamed', async () => {
     await expect(formBuilderPage.page.getByText(/question updated/i)).toBeVisible();
     await expect(formBuilderPage.page.locator('p').getByText(/an edited question label/i)).toBeVisible();
     const formTextContent = await formBuilderPage.schemaEditorContent().textContent();

--- a/src/components/interactive-builder/modals/question/form-field-context.tsx
+++ b/src/components/interactive-builder/modals/question/form-field-context.tsx
@@ -7,6 +7,8 @@ interface FormFieldContextType {
   setFormField: (value: FormField | ((prev: FormField) => FormField)) => void;
   concept: Concept;
   setConcept: React.Dispatch<React.SetStateAction<Concept>>;
+  isConceptValid?: boolean;
+  setIsConceptValid?: React.Dispatch<React.SetStateAction<boolean>>;
   updateParentFormField?: (updatedFormField: FormField) => void;
   isObsGrouped?: boolean;
 }
@@ -22,6 +24,7 @@ export const FormFieldProvider: React.FC<{
 }> = ({ children, initialFormField, isObsGrouped = false, selectedConcept = null, updateParentFormField }) => {
   const [formField, setFormFieldInternal] = useState<FormField>(initialFormField);
   const [concept, setConcept] = useState<Concept | null>(selectedConcept);
+  const [isConceptValid, setIsConceptValid] = useState<boolean>(true);
 
   const setFormField = useCallback(
     (valueOrUpdater: FormField | ((prev: FormField) => FormField)) => {
@@ -43,6 +46,8 @@ export const FormFieldProvider: React.FC<{
         setFormField,
         concept,
         setConcept,
+        isConceptValid,
+        setIsConceptValid,
         updateParentFormField,
         isObsGrouped,
       }}

--- a/src/components/interactive-builder/modals/question/question-form/common/concept-search/concept-search.component.tsx
+++ b/src/components/interactive-builder/modals/question/question-form/common/concept-search/concept-search.component.tsx
@@ -15,7 +15,6 @@ interface ConceptSearchProps {
   onClearSelectedConcept?: () => void;
   onSelectConcept: (concept: Concept) => void;
   retainConceptInContextAfterSearch?: boolean;
-  onConceptValidityChange?: (valid: boolean) => void;
 }
 
 const ConceptSearch: React.FC<ConceptSearchProps> = ({
@@ -24,7 +23,6 @@ const ConceptSearch: React.FC<ConceptSearchProps> = ({
   onClearSelectedConcept,
   onSelectConcept,
   retainConceptInContextAfterSearch = false,
-  onConceptValidityChange,
 }) => {
   const { t } = useTranslation();
   const [conceptToLookup, setConceptToLookup] = useState('');
@@ -37,7 +35,7 @@ const ConceptSearch: React.FC<ConceptSearchProps> = ({
     isLoadingConcept,
   } = useConceptId(defaultConcept);
   const [selectedConcept, setSelectedConcept] = useState<Concept>(initialConcept);
-  const { concept, setConcept } = useFormField();
+  const { concept, setConcept, setIsConceptValid } = useFormField();
 
   useEffect(() => {
     if (retainConceptInContextAfterSearch && initialConcept && !concept) {
@@ -45,34 +43,33 @@ const ConceptSearch: React.FC<ConceptSearchProps> = ({
     }
   }, [initialConcept, retainConceptInContextAfterSearch, concept, setConcept]);
 
-  useEffect(() => {
-    if (onConceptValidityChange) {
-      const valid = !(conceptLookupError || conceptNameLookupError);
-      onConceptValidityChange(valid);
-    }
-  }, [conceptLookupError, conceptNameLookupError, onConceptValidityChange]);
-
   const handleConceptChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => setConceptToLookup(event.target.value),
     [],
   );
+
+  useEffect(() => {
+    if (conceptLookupError || conceptNameLookupError) {
+      setIsConceptValid(false);
+    }
+  }, [conceptLookupError, conceptNameLookupError, setIsConceptValid]);
 
   const handleConceptSelect = useCallback(
     (concept: Concept) => {
       setConceptToLookup('');
       setSelectedConcept(concept);
       onSelectConcept(concept);
-      onConceptValidityChange?.(true);
+      setIsConceptValid(true);
     },
-    [onSelectConcept, onConceptValidityChange],
+    [onSelectConcept, setIsConceptValid],
   );
 
   const clearSelectedConcept = useCallback(() => {
     setSelectedConcept(null);
     setConceptToLookup('');
+    setIsConceptValid(true);
     if (onClearSelectedConcept) onClearSelectedConcept();
-    onConceptValidityChange?.(false);
-  }, [onClearSelectedConcept, onConceptValidityChange]);
+  }, [onClearSelectedConcept, setIsConceptValid]);
 
   return (
     <>

--- a/src/components/interactive-builder/modals/question/question-form/common/concept-search/concept-search.test.tsx
+++ b/src/components/interactive-builder/modals/question/question-form/common/concept-search/concept-search.test.tsx
@@ -45,9 +45,10 @@ jest.mock('@hooks/useConceptId', () => ({
 const onSelectConcept = jest.fn();
 const mockSetFormField = jest.fn();
 const setConcept = jest.fn();
+const setIsConceptValid = jest.fn();
 jest.mock('../../../form-field-context', () => ({
   ...jest.requireActual('../../../form-field-context'),
-  useFormField: () => ({ formField, setFormField: mockSetFormField, setConcept }),
+  useFormField: () => ({ formField, setFormField: mockSetFormField, setConcept, setIsConceptValid }),
 }));
 
 describe('Concept search component', () => {

--- a/src/components/interactive-builder/modals/question/question-form/question-types/inputs/obs/obs-type-question.component.tsx
+++ b/src/components/interactive-builder/modals/question/question-form/question-types/inputs/obs/obs-type-question.component.tsx
@@ -6,11 +6,7 @@ import { useFormField } from '../../../../form-field-context';
 import type { Concept, ConceptMapping, DatePickerType } from '@types';
 import styles from './obs-type-question.scss';
 
-interface ObsTypeQuestionProps {
-  setIsConceptIdValid?: React.Dispatch<React.SetStateAction<boolean>>;
-}
-
-const ObsTypeQuestion: React.FC<ObsTypeQuestionProps> = ({ setIsConceptIdValid }) => {
+const ObsTypeQuestion: React.FC = () => {
   const { t } = useTranslation();
   const { formField, setFormField, concept, setConcept } = useFormField();
 
@@ -81,7 +77,6 @@ const ObsTypeQuestion: React.FC<ObsTypeQuestionProps> = ({ setIsConceptIdValid }
         onClearSelectedConcept={clearSelectedConcept}
         onSelectConcept={handleConceptSelect}
         retainConceptInContextAfterSearch={true}
-        onConceptValidityChange={(valid) => setIsConceptIdValid?.(valid)}
       />
 
       {concept?.allowDecimal === false && (

--- a/src/components/interactive-builder/modals/question/question-form/question-types/inputs/obs/obs-type-question.component.tsx
+++ b/src/components/interactive-builder/modals/question/question-form/question-types/inputs/obs/obs-type-question.component.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { FormLabel, InlineNotification, FormGroup, Stack } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
 import ConceptSearch from '../../../common/concept-search/concept-search.component';
@@ -6,13 +6,16 @@ import { useFormField } from '../../../../form-field-context';
 import type { Concept, ConceptMapping, DatePickerType } from '@types';
 import styles from './obs-type-question.scss';
 
-const ObsTypeQuestion: React.FC = () => {
+interface ObsTypeQuestionProps {
+  setIsConceptIdValid?: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const ObsTypeQuestion: React.FC<ObsTypeQuestionProps> = ({ setIsConceptIdValid }) => {
   const { t } = useTranslation();
   const { formField, setFormField, concept, setConcept } = useFormField();
 
-  const getDatePickerType = useCallback((concept: Concept): DatePickerType | null => {
-    const conceptDataType = concept.datatype.name;
-    switch (conceptDataType) {
+  const getDatePickerType = useCallback((selectedConcept: Concept): DatePickerType | null => {
+    switch (selectedConcept.datatype.name) {
       case 'Datetime':
         return 'both';
       case 'Date':
@@ -78,6 +81,7 @@ const ObsTypeQuestion: React.FC = () => {
         onClearSelectedConcept={clearSelectedConcept}
         onSelectConcept={handleConceptSelect}
         retainConceptInContextAfterSearch={true}
+        onConceptValidityChange={(valid) => setIsConceptIdValid?.(valid)}
       />
 
       {concept?.allowDecimal === false && (

--- a/src/components/interactive-builder/modals/question/question-form/question-types/inputs/obs/obs-type-question.test.tsx
+++ b/src/components/interactive-builder/modals/question/question-form/question-types/inputs/obs/obs-type-question.test.tsx
@@ -10,6 +10,7 @@ import type { Concept } from '@types';
 
 const mockSetFormField = jest.fn();
 const setConcept = jest.fn();
+const setIsConceptValid = jest.fn();
 const formField: FormField = {
   id: '1',
   type: 'obs',
@@ -20,7 +21,7 @@ const formField: FormField = {
 
 jest.mock('../../../../form-field-context', () => ({
   ...jest.requireActual('../../../../form-field-context'),
-  useFormField: () => ({ formField, setFormField: mockSetFormField, setConcept }),
+  useFormField: () => ({ formField, setFormField: mockSetFormField, setConcept, setIsConceptValid }),
 }));
 
 const concepts: Array<Concept> = [

--- a/src/components/interactive-builder/modals/question/question-form/question-types/question-type.component.tsx
+++ b/src/components/interactive-builder/modals/question/question-form/question-types/question-type.component.tsx
@@ -3,27 +3,21 @@ import { ObsTypeQuestion, ProgramStateTypeQuestion, PatientIdentifierTypeQuestio
 import { useFormField } from '../../form-field-context';
 import type { QuestionType } from '@types';
 
-interface QuestionTypeComponentProps {
-  setIsConceptIdValid?: React.Dispatch<React.SetStateAction<boolean>>;
-}
-
-const componentMap: Partial<
-  Record<QuestionType, React.FC<{ setIsConceptIdValid?: React.Dispatch<React.SetStateAction<boolean>> }>>
-> = {
+const componentMap: Partial<Record<QuestionType, React.FC>> = {
   obs: ObsTypeQuestion,
   programState: ProgramStateTypeQuestion,
   patientIdentifier: PatientIdentifierTypeQuestion,
   obsGroup: ObsTypeQuestion,
 };
 
-const QuestionTypeComponent: React.FC<QuestionTypeComponentProps> = ({ setIsConceptIdValid }) => {
+const QuestionTypeComponent: React.FC = () => {
   const { formField } = useFormField();
   const Component = componentMap[formField.type as QuestionType];
   if (!Component) {
     console.error(`No component found for questiontype: ${formField.type}`);
     return null;
   }
-  return <Component setIsConceptIdValid={setIsConceptIdValid} />;
+  return <Component />;
 };
 
 export default QuestionTypeComponent;

--- a/src/components/interactive-builder/modals/question/question-form/question-types/question-type.component.tsx
+++ b/src/components/interactive-builder/modals/question/question-form/question-types/question-type.component.tsx
@@ -3,21 +3,27 @@ import { ObsTypeQuestion, ProgramStateTypeQuestion, PatientIdentifierTypeQuestio
 import { useFormField } from '../../form-field-context';
 import type { QuestionType } from '@types';
 
-const componentMap: Partial<Record<QuestionType, React.FC>> = {
+interface QuestionTypeComponentProps {
+  setIsConceptIdValid?: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const componentMap: Partial<
+  Record<QuestionType, React.FC<{ setIsConceptIdValid?: React.Dispatch<React.SetStateAction<boolean>> }>>
+> = {
   obs: ObsTypeQuestion,
   programState: ProgramStateTypeQuestion,
   patientIdentifier: PatientIdentifierTypeQuestion,
   obsGroup: ObsTypeQuestion,
 };
 
-const QuestionTypeComponent: React.FC = () => {
+const QuestionTypeComponent: React.FC<QuestionTypeComponentProps> = ({ setIsConceptIdValid }) => {
   const { formField } = useFormField();
-  const Component = componentMap[formField.type];
+  const Component = componentMap[formField.type as QuestionType];
   if (!Component) {
     console.error(`No component found for questiontype: ${formField.type}`);
     return null;
   }
-  return <Component />;
+  return <Component setIsConceptIdValid={setIsConceptIdValid} />;
 };
 
 export default QuestionTypeComponent;

--- a/src/components/interactive-builder/modals/question/question-form/question/question.component.tsx
+++ b/src/components/interactive-builder/modals/question/question-form/question/question.component.tsx
@@ -11,10 +11,9 @@ import styles from './question.scss';
 
 interface QuestionProps {
   checkIfQuestionIdExists: (idToTest: string) => boolean;
-  setIsConceptIdValid?: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const Question: React.FC<QuestionProps> = ({ checkIfQuestionIdExists, setIsConceptIdValid }) => {
+const Question: React.FC<QuestionProps> = ({ checkIfQuestionIdExists }) => {
   const { t } = useTranslation();
   const { formField, setFormField } = useFormField();
 
@@ -149,7 +148,7 @@ const Question: React.FC<QuestionProps> = ({ checkIfQuestionIdExists, setIsConce
           </RadioButtonGroup>
         </>
       )}
-      {formField.type && <QuestionTypeComponent setIsConceptIdValid={setIsConceptIdValid} />}
+      {formField.type && <QuestionTypeComponent />}
       {formField.questionOptions?.rendering && <RenderTypeComponent />}
     </>
   );

--- a/src/components/interactive-builder/modals/question/question-form/question/question.component.tsx
+++ b/src/components/interactive-builder/modals/question/question-form/question/question.component.tsx
@@ -11,9 +11,10 @@ import styles from './question.scss';
 
 interface QuestionProps {
   checkIfQuestionIdExists: (idToTest: string) => boolean;
+  setIsConceptIdValid?: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const Question: React.FC<QuestionProps> = ({ checkIfQuestionIdExists }) => {
+const Question: React.FC<QuestionProps> = ({ checkIfQuestionIdExists, setIsConceptIdValid }) => {
   const { t } = useTranslation();
   const { formField, setFormField } = useFormField();
 
@@ -148,7 +149,7 @@ const Question: React.FC<QuestionProps> = ({ checkIfQuestionIdExists }) => {
           </RadioButtonGroup>
         </>
       )}
-      {formField.type && <QuestionTypeComponent />}
+      {formField.type && <QuestionTypeComponent setIsConceptIdValid={setIsConceptIdValid} />}
       {formField.questionOptions?.rendering && <RenderTypeComponent />}
     </>
   );

--- a/src/components/interactive-builder/modals/question/question.modal.tsx
+++ b/src/components/interactive-builder/modals/question/question.modal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import flattenDeep from 'lodash-es/flattenDeep';
 import {
@@ -44,8 +44,7 @@ const QuestionModalContent: React.FC<QuestionModalProps> = ({
   onSchemaChange,
 }) => {
   const { t } = useTranslation();
-  const { formField, setFormField } = useFormField();
-  const [isConceptValid, setIsConceptValid] = useState(true);
+  const { formField, setFormField, isConceptValid } = useFormField();
 
   /**
    * NOTE - this does not support nested obsGroup questions
@@ -160,7 +159,7 @@ const QuestionModalContent: React.FC<QuestionModalProps> = ({
         <ModalBody>
           <FormGroup>
             <Stack gap={5}>
-              <Question checkIfQuestionIdExists={checkIfQuestionIdExists} setIsConceptIdValid={setIsConceptValid} />
+              <Question checkIfQuestionIdExists={checkIfQuestionIdExists} />
               {formField.questions?.length >= 1 && (
                 <Accordion size="lg">
                   {formField.questions.map((question, index) => (
@@ -177,10 +176,7 @@ const QuestionModalContent: React.FC<QuestionModalProps> = ({
                           handleUpdateParentFormField(updatedFormField, index)
                         }
                       >
-                        <Question
-                          checkIfQuestionIdExists={checkIfQuestionIdExists}
-                          setIsConceptIdValid={setIsConceptValid}
-                        />
+                        <Question checkIfQuestionIdExists={checkIfQuestionIdExists} />
                         <Button
                           kind="danger"
                           onClick={() => deleteObsGroupQuestion(index)}
@@ -210,6 +206,8 @@ const QuestionModalContent: React.FC<QuestionModalProps> = ({
               !formField ||
               !formField.id ||
               !isConceptValid ||
+              (formField.type === 'obs' &&
+                (!formField.questionOptions.concept || formField.questionOptions.concept === '')) ||
               (!formField.questions && checkIfQuestionIdExists(formField.id)) ||
               !formField.questionOptions?.rendering
             }

--- a/src/components/interactive-builder/modals/question/question.modal.tsx
+++ b/src/components/interactive-builder/modals/question/question.modal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import flattenDeep from 'lodash-es/flattenDeep';
 import {
@@ -45,6 +45,7 @@ const QuestionModalContent: React.FC<QuestionModalProps> = ({
 }) => {
   const { t } = useTranslation();
   const { formField, setFormField } = useFormField();
+  const [isConceptValid, setIsConceptValid] = useState(true);
 
   /**
    * NOTE - this does not support nested obsGroup questions
@@ -159,7 +160,7 @@ const QuestionModalContent: React.FC<QuestionModalProps> = ({
         <ModalBody>
           <FormGroup>
             <Stack gap={5}>
-              <Question checkIfQuestionIdExists={checkIfQuestionIdExists} />
+              <Question checkIfQuestionIdExists={checkIfQuestionIdExists} setIsConceptIdValid={setIsConceptValid} />
               {formField.questions?.length >= 1 && (
                 <Accordion size="lg">
                   {formField.questions.map((question, index) => (
@@ -176,7 +177,10 @@ const QuestionModalContent: React.FC<QuestionModalProps> = ({
                           handleUpdateParentFormField(updatedFormField, index)
                         }
                       >
-                        <Question checkIfQuestionIdExists={checkIfQuestionIdExists} />
+                        <Question
+                          checkIfQuestionIdExists={checkIfQuestionIdExists}
+                          setIsConceptIdValid={setIsConceptValid}
+                        />
                         <Button
                           kind="danger"
                           onClick={() => deleteObsGroupQuestion(index)}
@@ -205,6 +209,7 @@ const QuestionModalContent: React.FC<QuestionModalProps> = ({
             disabled={
               !formField ||
               !formField.id ||
+              !isConceptValid ||
               (!formField.questions && checkIfQuestionIdExists(formField.id)) ||
               !formField.questionOptions?.rendering
             }

--- a/src/components/interactive-builder/modals/question/question.modal.tsx
+++ b/src/components/interactive-builder/modals/question/question.modal.tsx
@@ -207,7 +207,7 @@ const QuestionModalContent: React.FC<QuestionModalProps> = ({
               !formField.id ||
               !isConceptValid ||
               (formField.type === 'obs' &&
-                (!formField.questionOptions.concept || formField.questionOptions.concept === '')) ||
+                (!formField.questionOptions?.concept || formField.questionOptions?.concept === '')) ||
               (!formField.questions && checkIfQuestionIdExists(formField.id)) ||
               !formField.questionOptions?.rendering
             }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

- Introduce state to track concept validity.
- Pass a concept validity callback down to the obs-type question component via QuestionTypeComponent.
- Disable the Save button if the concept is invalid.
- Ensure only one ConceptSearch is rendered for obs-type questions.

## Screenshots
<!-- Required if you are making UI changes. -->
Before

https://github.com/user-attachments/assets/3d1589ac-3ae9-4d0c-b4c8-4b98782bfc7c


After

https://github.com/user-attachments/assets/0e3d5d0a-493f-4d90-b791-abe6243d8f9f


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4493

## Other
<!-- Anything not covered above -->
