### PR TITLE
(feat) O3-3955: Add support for question info

### DIFF
--- a/src/components/interactive-builder/modals/question/question-form/question/question.component.tsx
+++ b/src/components/interactive-builder/modals/question/question-form/question/question.component.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { TextInput, Button, Select, SelectItem, RadioButtonGroup, RadioButton } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
 import RenderTypeComponent from '../rendering-types/rendering-type.component';
@@ -16,6 +16,7 @@ interface QuestionProps {
 const Question: React.FC<QuestionProps> = ({ checkIfQuestionIdExists }) => {
   const { t } = useTranslation();
   const { formField, setFormField } = useFormField();
+  const [showQuestionInfoInput, setShowQuestionInfoInput] = useState(formField.questionInfo ? true : false);
 
   const convertLabelToCamelCase = () => {
     const camelCasedLabel = formField.label
@@ -30,6 +31,12 @@ const Question: React.FC<QuestionProps> = ({ checkIfQuestionIdExists }) => {
   const isQuestionIdDuplicate = useCallback(() => {
     return checkIfQuestionIdExists(formField.id);
   }, [formField.id, checkIfQuestionIdExists]);
+
+  const handleQuestionInfoLabel = () => {
+    const { questionInfo, ...updatedFormField } = formField;
+    setFormField(updatedFormField);
+    setShowQuestionInfoInput(false);
+  };
 
   return (
     <>
@@ -105,6 +112,37 @@ const Question: React.FC<QuestionProps> = ({ checkIfQuestionIdExists }) => {
             ))
           : renderingTypes.map((type, key) => <SelectItem key={key} text={type} value={type} />)}
       </Select>
+      <RadioButtonGroup
+        defaultSelected={formField.questionInfo ? 'questionInfoProvided' : 'questionInfoNotProvided'}
+        name="isQuestionInfoProvided"
+        legendText={t('isQuestionInfoProvided', 'Provide question info?')}
+      >
+        <RadioButton
+          id="questionInfoProvided"
+          defaultChecked={formField.questionInfo ? true : false}
+          labelText={t('yes', 'Yes')}
+          onClick={() => setShowQuestionInfoInput(true)}
+          value="questionInfoProvided"
+        />
+        <RadioButton
+          id="questionInfoNotProvided"
+          defaultChecked={formField.questionInfo ? false : true}
+          labelText={t('no', 'No')}
+          onClick={() => handleQuestionInfoLabel()}
+          value="questionInfoNotProvided"
+        />
+      </RadioButtonGroup>
+      {showQuestionInfoInput && (
+        <TextInput
+          id="questionInfo"
+          labelText={t('questionInfo', 'question Info')}
+          placeholder={t('questionInfoPlaceholder', 'Info About the question')}
+          value={formField?.questionInfo}
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+            setFormField({ ...formField, questionInfo: event.target.value })
+          }
+        />
+      )}
       {formField.questionOptions && formField.questionOptions.rendering !== 'markdown' && (
         <>
           <TextInput

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,7 @@ export interface Schema {
         value?: string;
         type: string;
         required?: string | boolean | RequiredFieldProps;
+        questionInfo?: string;
         questionOptions: {
           type?: string;
           concept?: string;
@@ -120,6 +121,7 @@ export interface Question {
   questions?: Array<Question>;
   required?: string | boolean | RequiredFieldProps;
   validators?: Array<Record<string, string>>;
+  questionInfo?: string;
 }
 
 export interface QuestionOptions {


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR introduces an optional text input in the question modal, allowing users to provide additional information about a question. This information is displayed as a tooltip in the form preview.

Implementation Details:

* Users can choose whether to add question info.
* If they opt to provide info, a text input appears where they can enter the tooltip content.
* If no info is provided, the tooltip remains hidden.

## Screenshots
![Screenshot 2025-03-20 015640](https://github.com/user-attachments/assets/ad8d5410-68fe-4a51-b8d9-c873c3b1f304)
![Screenshot 2025-03-20 020029](https://github.com/user-attachments/assets/8a347844-7149-45d8-a236-6c442adb6b89)
![Screenshot 2025-03-20 020048](https://github.com/user-attachments/assets/b53b48f6-82e9-402e-ae88-30dd2b77d5de)
![Screenshot 2025-03-20 020102](https://github.com/user-attachments/assets/c6c72600-da47-422f-adad-da8dcf6bb881)


## Related Issue
https://openmrs.atlassian.net/browse/O3-3955

## Other
Added new translation keys:

* "isQuestionInfoProvided"
* "questionInfo"
* "questionInfoPlaceholder"
