### PR TITLE
(fix) Reset N/A rendering map fields

### DIFF
--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -76,7 +76,7 @@ export const configSchema = {
       Datetime: ['datetime', 'fixed-value'],
       Boolean: ['toggle', 'select', 'radio', 'content-switcher', 'fixed-value'],
       Rule: ['repeating', 'group'],
-      'N/A': ['text', 'textarea'],
+      'N/A': [],
       Complex: ['file'],
     },
   },


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This was changed by mistake in a [previous PR](https://github.com/openmrs/openmrs-esm-form-builder/pull/439). The N/A concept types shouldn't be mapped to any fields by default and should warn when such a concept is tagged to rendering type fields. 

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
