### PR TITLE
(fix) O3-4617: Use form field answer label instead of concept label

### DIFF
--- a/src/components/interactive-builder/modals/question/question-form/rendering-types/inputs/select/select-answers.component.tsx
+++ b/src/components/interactive-builder/modals/question/question-form/rendering-types/inputs/select/select-answers.component.tsx
@@ -113,7 +113,13 @@ const SelectAnswers: React.FC = () => {
       }));
     }
 
-    // Merge concept answers with any additional form field answers
+    const formFieldAnswerLabelsMap = new Map(formFieldAnswers.map((answer) => [answer.concept, answer.label]));
+
+    const answersFromConceptWithLabelsFromFormField = conceptAnswerItems.map((item) => ({
+      id: item.id,
+      text: formFieldAnswerLabelsMap.get(item.id) ?? item.text,
+    }));
+
     const additionalAnswers = formFieldAnswers
       .filter((answer) => !conceptAnswerItems.some((item) => item.id === answer.concept))
       .map((answer) => ({
@@ -121,7 +127,7 @@ const SelectAnswers: React.FC = () => {
         text: answer.label,
       }));
 
-    return [...conceptAnswerItems, ...additionalAnswers];
+    return [...answersFromConceptWithLabelsFromFormField, ...additionalAnswers];
   }, [concept?.answers, formField.questionOptions?.answers]);
 
   const convertAnswerItemsToString = useCallback((item: AnswerItem) => item.text, []);


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR updates the labels for the answers to use the answers that from the JSON schema rather than using the concept's label. Previously, if you updated the label of an answer in the JSON schema, it would show that answer as unselected.

## Screenshots
<!-- Required if you are making UI changes. -->
Before fix:

https://github.com/user-attachments/assets/1c959360-d2c0-4b6d-99c2-14714d351ad4

After fix:

https://github.com/user-attachments/assets/8f02ec7c-af1a-41fc-94e8-7a55f2a8beb8



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-4617

## Other
<!-- Anything not covered above -->
