### PR TITLE
(fix) O3-4652 : Change direction of select answer's multiselect from top to bottom

### DIFF
--- a/src/components/interactive-builder/modals/question/question-form/rendering-types/inputs/select/select-answers.component.tsx
+++ b/src/components/interactive-builder/modals/question/question-form/rendering-types/inputs/select/select-answers.component.tsx
@@ -137,7 +137,7 @@ const SelectAnswers: React.FC = () => {
       {answerItems.length > 0 && (
         <MultiSelect
           className={styles.multiSelect}
-          direction="top"
+          direction="bottom"
           id="selectAnswers"
           items={answerItems}
           itemToString={convertAnswerItemsToString}


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
The current setting for the MultiSelect component uses direction="top", which causes the dropdown to hide the label text ("Select answers to display") when opened. Updating the direction to "bottom" ensures that the label and other UI elements remain visible and accessible.
## Screenshots
<!-- Required if you are making UI changes. -->
Before
![Screenshot 2025-04-18 170357](https://github.com/user-attachments/assets/671c87c2-372e-4ff9-aa02-c1d04a4d7647)
After 
![Screenshot 2025-04-17 183141](https://github.com/user-attachments/assets/e7b78c2e-cd04-4151-b8f4-7526e5669556)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4652
## Other
<!-- Anything not covered above -->
