### PR TITLE
(fix) O3-4658: Search input should clear after selecting a concept as an additional answer

### DIFF
--- a/src/components/interactive-builder/modals/question/question-form/common/concept-search/concept-search.component.tsx
+++ b/src/components/interactive-builder/modals/question/question-form/common/concept-search/concept-search.component.tsx
@@ -24,7 +24,7 @@ const ConceptSearch: React.FC<ConceptSearchProps> = ({
   onClearSelectedConcept,
   onSelectConcept,
   retainConceptInContextAfterSearch = false,
-  clearSearchAfterSelection,
+  clearSearchAfterSelection = false,
 }) => {
   const { t } = useTranslation();
   const [conceptToLookup, setConceptToLookup] = useState('');

--- a/src/components/interactive-builder/modals/question/question-form/common/concept-search/concept-search.component.tsx
+++ b/src/components/interactive-builder/modals/question/question-form/common/concept-search/concept-search.component.tsx
@@ -15,6 +15,7 @@ interface ConceptSearchProps {
   onClearSelectedConcept?: () => void;
   onSelectConcept: (concept: Concept) => void;
   retainConceptInContextAfterSearch?: boolean;
+  clearSearchAfterSelection?: boolean;
 }
 
 const ConceptSearch: React.FC<ConceptSearchProps> = ({
@@ -23,6 +24,7 @@ const ConceptSearch: React.FC<ConceptSearchProps> = ({
   onClearSelectedConcept,
   onSelectConcept,
   retainConceptInContextAfterSearch = false,
+  clearSearchAfterSelection,
 }) => {
   const { t } = useTranslation();
   const [conceptToLookup, setConceptToLookup] = useState('');
@@ -54,16 +56,6 @@ const ConceptSearch: React.FC<ConceptSearchProps> = ({
     }
   }, [conceptLookupError, conceptNameLookupError, setIsConceptValid]);
 
-  const handleConceptSelect = useCallback(
-    (concept: Concept) => {
-      setConceptToLookup('');
-      setSelectedConcept(concept);
-      onSelectConcept(concept);
-      setIsConceptValid(true);
-    },
-    [onSelectConcept, setIsConceptValid],
-  );
-
   const clearSelectedConcept = useCallback(() => {
     setSelectedConcept(null);
     setConceptToLookup('');
@@ -71,6 +63,19 @@ const ConceptSearch: React.FC<ConceptSearchProps> = ({
     if (onClearSelectedConcept) onClearSelectedConcept();
   }, [onClearSelectedConcept, setIsConceptValid]);
 
+  const handleConceptSelect = useCallback(
+    (concept: Concept) => {
+      setConceptToLookup('');
+      setSelectedConcept(concept);
+      onSelectConcept(concept);
+      setIsConceptValid(true);
+
+      if (clearSearchAfterSelection) {
+        clearSelectedConcept();
+      }
+    },
+    [onSelectConcept, setIsConceptValid, clearSelectedConcept, clearSearchAfterSelection],
+  );
   return (
     <>
       <FormLabel className={styles.label}>

--- a/src/components/interactive-builder/modals/question/question-form/rendering-types/inputs/select/select-answers.component.tsx
+++ b/src/components/interactive-builder/modals/question/question-form/rendering-types/inputs/select/select-answers.component.tsx
@@ -163,6 +163,7 @@ const SelectAnswers: React.FC = () => {
           <ConceptSearch
             label={t('searchForAnswerConcept', 'Search for a concept to add as an answer')}
             onSelectConcept={handleSelectAdditionalAnswer}
+            clearSearchAfterSelection={true}
           />
           {addedAnswers.length > 0 ? (
             <div>


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR introduces a new `clearSearchAfterSelection` prop to the ConceptSearch component. It enables conditional clearing of the internal search input and selected concept state upon selecting a concept.

- In obs-type-question, where the selected concept should remain visible in the input after selection.
 
- In search-answers, where the search bar should be cleared after adding a concept to improve user flow for selecting multiple answers.

## Screenshots
<!-- Required if you are making UI changes. -->
Before

https://github.com/user-attachments/assets/d4f72ca2-e4ee-4e80-89fc-e78cc0c9ccd3

After

https://github.com/user-attachments/assets/387f548a-f9b3-45f7-b5d3-9ca6a58f8bcd


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4658

## Other
<!-- Anything not covered above -->
