### PR TITLE
(fix) O3-4449: Question label input should be at the top

### DIFF
--- a/src/components/interactive-builder/modals/question/question-form/question/question.component.tsx
+++ b/src/components/interactive-builder/modals/question/question-form/question/question.component.tsx
@@ -87,6 +87,24 @@ const Question: React.FC<QuestionProps> = ({ checkIfQuestionIdExists }) => {
 
   return (
     <>
+      {formField.questionOptions && formField.questionOptions.rendering !== 'markdown' && (
+        <TextInput
+          id="questionLabel"
+          labelText={
+            <RequiredLabel
+              isRequired={formField?.required && formField?.required === 'true' ? true : false}
+              text={t('questionLabel', 'Label')}
+              t={t}
+            />
+          }
+          placeholder={t('labelPlaceholder', 'e.g. Type of Anaesthesia')}
+          value={formField?.label}
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+            setFormField({ ...formField, label: event.target.value })
+          }
+          required
+        />
+      )}
       <TextInput
         id="questionId"
         invalid={!!formField?.id && isQuestionIdDuplicate()}
@@ -159,22 +177,6 @@ const Question: React.FC<QuestionProps> = ({ checkIfQuestionIdExists }) => {
       </Select>
       {formField.questionOptions && formField.questionOptions.rendering !== 'markdown' && (
         <>
-          <TextInput
-            id="questionLabel"
-            labelText={
-              <RequiredLabel
-                isRequired={formField?.required && formField?.required === 'true' ? true : false}
-                text={t('questionLabel', 'Label')}
-                t={t}
-              />
-            }
-            placeholder={t('labelPlaceholder', 'e.g. Type of Anaesthesia')}
-            value={formField?.label}
-            onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-              setFormField({ ...formField, label: event.target.value })
-            }
-            required
-          />
           <RadioButtonGroup
             name="isQuestionRequired"
             legendText={t(

--- a/src/components/interactive-builder/modals/question/question.modal.tsx
+++ b/src/components/interactive-builder/modals/question/question.modal.tsx
@@ -223,7 +223,9 @@ const QuestionModalContent: React.FC<QuestionModalProps> = ({
 const QuestionModal: React.FC<QuestionModalProps> = (props) => {
   return (
     <>
-      <FormFieldProvider initialFormField={props.formField ?? { type: 'control', questionOptions: undefined, id: '' }}>
+      <FormFieldProvider
+        initialFormField={props.formField ?? { type: 'control', questionOptions: { rendering: 'text' }, id: '' }}
+      >
         <QuestionModalContent {...props} />
       </FormFieldProvider>
     </>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR changes the question label input to be at the top of the question modal. Since the label input is rendered only if the `renderingType` is not `markdown`, I've initialized the `renderingType` to be `text`.

## Screenshots
<!-- Required if you are making UI changes. -->
<img width="821" alt="Screenshot 2025-04-29 at 1 04 29 PM" src="https://github.com/user-attachments/assets/8fb4ec46-9467-4738-bd9b-945bf949be06" />


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-4449

## Other
<!-- Anything not covered above -->
