### PR TITLE
(feat) O3-3958: Add a select all option for concept answers

### DIFF
--- a/e2e/specs/create-form-with-interactive-builder.spec.ts
+++ b/e2e/specs/create-form-with-interactive-builder.spec.ts
@@ -31,12 +31,12 @@ const formDetails = {
                 concept: '89c5bc03-8ce2-40d8-a77d-20b5a62a1ca1',
                 answers: [
                   {
-                    concept: '1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-                    label: 'No',
-                  },
-                  {
                     concept: '1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
                     label: 'Yes',
+                  },
+                  {
+                    concept: '1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+                    label: 'No',
                   },
                 ],
               },
@@ -183,12 +183,6 @@ test('Create a form using the interactive builder', async ({ page, context }) =>
     await formBuilderPage.page.getByRole('menuitem', { name: /tested for covid 19/i }).click();
   });
 
-  await test.step('And then I select `Yes` and `No` as the answers to display', async () => {
-    await formBuilderPage.selectAnswersDropdown().click();
-    await formBuilderPage.page.getByRole('option', { name: 'No' }).click();
-    await formBuilderPage.page.getByRole('option', { name: 'Yes' }).click();
-  });
-
   await test.step('And then I click on `Save`', async () => {
     await expect(formBuilderPage.saveButton()).toBeEnabled();
     await formBuilderPage.saveButton().click();
@@ -243,34 +237,9 @@ test('Create a form using the interactive builder', async ({ page, context }) =>
       ],
       pages: [
         {
-          label: 'Screening',
+          ...formDetails.pages[0],
           sections: [
-            {
-              label: 'Testing history',
-              isExpanded: 'true',
-              questions: [
-                {
-                  type: 'obs',
-                  questionOptions: {
-                    rendering: 'radio',
-                    concept: '89c5bc03-8ce2-40d8-a77d-20b5a62a1ca1',
-                    answers: [
-                      {
-                        concept: '1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-                        label: 'No',
-                      },
-                      {
-                        concept: '1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-                        label: 'Yes',
-                      },
-                    ],
-                  },
-                  id: 'everTestedForCovid19',
-                  label: 'Have you been ever been tested for COVID-19?',
-                  required: true,
-                },
-              ],
-            },
+            formDetails.pages[0].sections[0],
             {
               label: 'Visit Details',
               isExpanded: 'true',

--- a/src/components/interactive-builder/modals/question/question-form/rendering-types/inputs/select/select-answers.component.tsx
+++ b/src/components/interactive-builder/modals/question/question-form/rendering-types/inputs/select/select-answers.component.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { InlineNotification, MultiSelect, Stack } from '@carbon/react';
 import { DndContext, type DragEndEvent } from '@dnd-kit/core';
 import { arrayMove, SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
@@ -20,6 +20,7 @@ const SelectAnswers: React.FC = () => {
   const { formField, concept, setFormField } = useFormField();
   const [addedAnswers, setAddedAnswers] = useState<AnswerItem[]>([]);
   const [invalidAnswerIds, setInvalidAnswerIds] = useState<string[]>([]);
+  const initializedConceptUuid = useRef<string | null>(null);
 
   // Reset the additionally selected answers when the concept changes
   useEffect(() => {
@@ -28,9 +29,16 @@ const SelectAnswers: React.FC = () => {
     }
   }, [concept]);
 
-  // Initialize the selected answers to be the concept's answers
+  // Initialize the selected answers to the concept's answers, once per concept.
+  // The once-per-concept guard keeps a cleared selection cleared instead of
+  // re-selecting every answer whenever the answers list becomes empty.
   useEffect(() => {
-    if (concept?.answers?.length && !formField.questionOptions?.answers?.length) {
+    if (!concept || initializedConceptUuid.current === concept.uuid) {
+      return;
+    }
+    initializedConceptUuid.current = concept.uuid;
+
+    if (concept.answers?.length && !formField.questionOptions?.answers?.length) {
       const initialAnswers = concept.answers.map((answer) => ({
         concept: answer.uuid,
         label: answer.display,
@@ -134,10 +142,17 @@ const SelectAnswers: React.FC = () => {
 
     // If no answers from concept but we have form field answers, use those
     if (conceptAnswerItems.length === 0 && formFieldAnswers.length > 0) {
-      return formFieldAnswers.map((answer) => ({
-        id: answer.concept,
-        text: answer.label,
-      }));
+      return [
+        ...formFieldAnswers.map((answer) => ({
+          id: answer.concept,
+          text: answer.label,
+        })),
+        {
+          id: 'select-all',
+          text: t('selectAllOptions', 'Select all options'),
+          isSelectAll: true,
+        },
+      ];
     }
 
     const formFieldAnswerLabelsMap = new Map(formFieldAnswers.map((answer) => [answer.concept, answer.label]));
@@ -159,11 +174,11 @@ const SelectAnswers: React.FC = () => {
       ...additionalAnswers,
       {
         id: 'select-all',
-        text: 'Select all options',
+        text: t('selectAllOptions', 'Select all options'),
         isSelectAll: true,
       },
     ];
-  }, [concept?.answers, formField.questionOptions?.answers]);
+  }, [concept?.answers, formField.questionOptions?.answers, t]);
 
   const validateAnswers = useCallback(async () => {
     if (!answerItems.length) {

--- a/src/components/interactive-builder/modals/question/question-form/rendering-types/inputs/select/select-answers.component.tsx
+++ b/src/components/interactive-builder/modals/question/question-form/rendering-types/inputs/select/select-answers.component.tsx
@@ -21,11 +21,30 @@ const SelectAnswers: React.FC = () => {
   const [addedAnswers, setAddedAnswers] = useState<AnswerItem[]>([]);
   const [invalidAnswerIds, setInvalidAnswerIds] = useState<string[]>([]);
 
+  // Reset the additionally selected answers when the concept changes
   useEffect(() => {
     if (!concept) {
       setAddedAnswers([]);
     }
   }, [concept]);
+
+  // Initialize the selected answers to be the concept's answers
+  useEffect(() => {
+    if (concept?.answers?.length && !formField.questionOptions?.answers?.length) {
+      const initialAnswers = concept.answers.map((answer) => ({
+        concept: answer.uuid,
+        label: answer.display,
+      }));
+
+      setFormField((prevField) => ({
+        ...prevField,
+        questionOptions: {
+          ...prevField.questionOptions,
+          answers: initialAnswers,
+        },
+      }));
+    }
+  }, [concept, formField.questionOptions?.answers, setFormField]);
 
   const selectedAnswers = useMemo(() => {
     const answers =
@@ -39,10 +58,12 @@ const SelectAnswers: React.FC = () => {
 
   const handleSelectAnswers = useCallback(
     ({ selectedItems }: { selectedItems: Array<AnswerItem> }) => {
-      const mappedAnswers = selectedItems.map((answer) => ({
-        concept: answer.id,
-        label: answer.text,
-      }));
+      const mappedAnswers = selectedItems
+        .filter((answer) => answer.id !== 'select-all')
+        .map((answer) => ({
+          concept: answer.id,
+          label: answer.text,
+        }));
 
       setFormField((prevField) => {
         const currentAnswers = prevField.questionOptions?.answers || [];
@@ -133,7 +154,15 @@ const SelectAnswers: React.FC = () => {
         text: answer.label,
       }));
 
-    return [...answersFromConceptWithLabelsFromFormField, ...additionalAnswers];
+    return [
+      ...answersFromConceptWithLabelsFromFormField,
+      ...additionalAnswers,
+      {
+        id: 'select-all',
+        text: 'Select all options',
+        isSelectAll: true,
+      },
+    ];
   }, [concept?.answers, formField.questionOptions?.answers]);
 
   const validateAnswers = useCallback(async () => {
@@ -144,7 +173,10 @@ const SelectAnswers: React.FC = () => {
 
     const originalAnswerIds = new Set((concept?.answers || []).map((ans) => ans.uuid));
     const invalidIds: string[] = [];
-    const uniqueAnswers = Array.from(new Map(answerItems.map((a) => [a.id, a])).values());
+    // Filter out the 'select-all' option before validation
+    const uniqueAnswers = Array.from(
+      new Map(answerItems.filter((a) => a.id !== 'select-all').map((a) => [a.id, a])).values(),
+    );
 
     for (const answer of uniqueAnswers) {
       if (!originalAnswerIds.has(answer.id)) {
@@ -219,7 +251,7 @@ const SelectAnswers: React.FC = () => {
 
   return (
     <Stack gap={5}>
-      {answerItems.length > 0 && (
+      {answerItems.length > 1 && (
         <MultiSelect
           className={styles.multiSelect}
           direction="bottom"

--- a/src/components/interactive-builder/modals/question/question-form/rendering-types/inputs/select/select-answers.test.tsx
+++ b/src/components/interactive-builder/modals/question/question-form/rendering-types/inputs/select/select-answers.test.tsx
@@ -88,6 +88,42 @@ describe('Select answers component', () => {
     expect(answerOption2).toBeChecked();
   });
 
+  it('keeps a cleared selection cleared instead of re-selecting every answer', async () => {
+    const user = userEvent.setup();
+    renderComponent();
+    const answersMenu = screen.getByRole('combobox', {
+      name: /select answers to display/i,
+    });
+
+    await user.click(answersMenu);
+    await user.click(screen.getByRole('checkbox', { name: /answer 1/i }));
+    await user.click(screen.getByRole('checkbox', { name: /answer 2/i }));
+
+    expect(screen.getByRole('checkbox', { name: /answer 1/i })).not.toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /answer 2/i })).not.toBeChecked();
+  });
+
+  it('renders the answers menu when a saved custom answer exists and the concept has no answers', () => {
+    render(
+      <FormFieldProvider
+        initialFormField={{
+          ...formField,
+          questionOptions: {
+            rendering: 'select',
+            answers: [{ concept: '999', label: 'Custom answer' }],
+          },
+        }}
+        selectedConcept={{ ...concept, answers: [] }}>
+        <SelectAnswers />
+      </FormFieldProvider>,
+    );
+
+    const answersMenu = screen.getByRole('combobox', {
+      name: /select answers to display/i,
+    });
+    expect(answersMenu).toBeInTheDocument();
+  });
+
   it('lets users add additional answers if concept is of datatype coded', async () => {
     const user = userEvent.setup();
     renderComponent();

--- a/src/components/interactive-builder/modals/question/question-form/rendering-types/inputs/select/select-answers.test.tsx
+++ b/src/components/interactive-builder/modals/question/question-form/rendering-types/inputs/select/select-answers.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import SelectAnswers from './select-answers.component';
 import { useConceptId } from '@hooks/useConceptId';
 import { useConceptLookup } from '@hooks/useConceptLookup';
@@ -69,7 +69,7 @@ describe('Select answers component', () => {
     ).toBeInTheDocument();
   });
 
-  it('lets user select answers provided by concept', async () => {
+  it('shows answers provided by concept as selected initially', async () => {
     const user = userEvent.setup();
     renderComponent();
     const answersMenu = screen.getByRole('combobox', {
@@ -78,20 +78,14 @@ describe('Select answers component', () => {
     expect(answersMenu).toBeInTheDocument();
 
     await user.click(answersMenu);
-    const answerOption1 = screen.getByRole('option', { name: /answer 1/i });
-    expect(answerOption1).toBeInTheDocument();
-    expect(screen.getByText(/answer 2/i)).toBeInTheDocument();
-    await user.click(answerOption1);
-    const option = screen.getByRole('option', {
+    const answerOption1 = screen.getByRole('checkbox', {
       name: /answer 1/i,
     });
-    expect(within(option).getByText(/answer 1/i)).toBeInTheDocument();
-
-    expect(
-      screen.getByRole('combobox', {
-        name: /select answers to display/i,
-      }),
-    ).toBeInTheDocument();
+    const answerOption2 = screen.getByRole('checkbox', {
+      name: /answer 2/i,
+    });
+    expect(answerOption1).toBeChecked();
+    expect(answerOption2).toBeChecked();
   });
 
   it('lets users add additional answers if concept is of datatype coded', async () => {

--- a/translations/en.json
+++ b/translations/en.json
@@ -266,6 +266,7 @@
   "sections": "Sections",
   "select": "Select",
   "selectableOrders": "Selectable Orders",
+  "selectAllOptions": "Select all options",
   "selectAnswersToDisplay": "Select answers to display",
   "selectForm": "Select Form",
   "selectLanguage": "Select language",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR adds the option `Select all` for when users are selecting answers from a concept.

## Screenshots
<!-- Required if you are making UI changes. -->

https://github.com/user-attachments/assets/38ad795a-6d13-4fac-ace5-a48e291e3bd0


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-3958

## Other
<!-- Anything not covered above -->
