### PR TITLE
(fix): Add title text to language dropdown

### DIFF
--- a/src/components/form-editor/form-editor.component.tsx
+++ b/src/components/form-editor/form-editor.component.tsx
@@ -315,18 +315,6 @@ const FormEditorContent: React.FC<TranslationFnProps> = ({ t }) => {
             <div className={styles.heading}>
               <span className={styles.tabHeading}>{t('schemaEditor', 'Schema editor')}</span>
               <div className={styles.topBtns}>
-                <Dropdown
-                  id="target-language"
-                  items={languageOptions}
-                  itemToString={(item) => item?.label ?? ''}
-                  label={t('selectLanguage', 'Select language')}
-                  titleText=""
-                  selectedItem={languageOptions.find((opt) => opt.code === selectedLanguageCode)}
-                  onChange={({ selectedItem }) => {
-                    if (selectedItem) setSelectedLanguageCode(selectedItem.code);
-                  }}
-                />
-
                 {!schema ? (
                   <FileUploader
                     onChange={handleSchemaImport}
@@ -348,6 +336,17 @@ const FormEditorContent: React.FC<TranslationFnProps> = ({ t }) => {
                     {t('inputDummySchema', 'Input dummy schema')}
                   </Button>
                 ) : null}
+                <Dropdown
+                  id="target-language"
+                  items={languageOptions}
+                  itemToString={(item) => item?.label ?? ''}
+                  label={t('selectLanguage', 'Select language')}
+                  titleText={t('previewFormIn', 'Preview form in')}
+                  selectedItem={languageOptions.find((opt) => opt.code === selectedLanguageCode)}
+                  onChange={({ selectedItem }) => {
+                    if (selectedItem) setSelectedLanguageCode(selectedItem.code);
+                  }}
+                />
                 <Button kind="ghost" onClick={handleRenderSchemaChanges} disabled={invalidJsonErrorMessage}>
                   <span>{t('renderChanges', 'Render changes')}</span>
                 </Button>

--- a/src/components/form-editor/form-editor.component.tsx
+++ b/src/components/form-editor/form-editor.component.tsx
@@ -336,21 +336,20 @@ const FormEditorContent: React.FC<TranslationFnProps> = ({ t }) => {
                     {t('inputDummySchema', 'Input dummy schema')}
                   </Button>
                 ) : null}
-                <div className={styles.dropdownContainer}>
-                  <Dropdown
-                    id="target-language"
-                    items={languageOptions}
-                    itemToString={(item) => item?.label ?? ''}
-                    label={t('selectLanguage', 'Select language')}
-                    onChange={({ selectedItem }) => {
-                      if (selectedItem) setSelectedLanguageCode(selectedItem.code);
-                    }}
-                    titleText={t('previewFormIn', 'Preview form in')}
-                    selectedItem={languageOptions.find((opt) => opt.code === selectedLanguageCode)}
-                    type="inline"
-                  />
-                  
-                </div>
+                <Dropdown
+                  id="target-language"
+                  items={languageOptions}
+                  itemToString={(item) => item?.label ?? ''}
+                  label={t('selectLanguage', 'Select language')}
+                  onChange={({ selectedItem }) => {
+                    if (selectedItem) setSelectedLanguageCode(selectedItem.code);
+                  }}
+                  titleText={t('previewFormIn', 'Preview form in')}
+                  selectedItem={languageOptions.find((opt) => opt.code === selectedLanguageCode)}
+                  type="inline"
+                  className={styles.dropdown}
+                />
+
                 <Button kind="ghost" onClick={handleRenderSchemaChanges} disabled={invalidJsonErrorMessage}>
                   <span>{t('renderChanges', 'Render changes')}</span>
                 </Button>

--- a/src/components/form-editor/form-editor.component.tsx
+++ b/src/components/form-editor/form-editor.component.tsx
@@ -336,17 +336,22 @@ const FormEditorContent: React.FC<TranslationFnProps> = ({ t }) => {
                     {t('inputDummySchema', 'Input dummy schema')}
                   </Button>
                 ) : null}
-                <Dropdown
-                  id="target-language"
-                  items={languageOptions}
-                  itemToString={(item) => item?.label ?? ''}
-                  label={t('selectLanguage', 'Select language')}
-                  titleText={t('previewFormIn', 'Preview form in')}
-                  selectedItem={languageOptions.find((opt) => opt.code === selectedLanguageCode)}
-                  onChange={({ selectedItem }) => {
-                    if (selectedItem) setSelectedLanguageCode(selectedItem.code);
-                  }}
-                />
+                <div className={styles.dropdownContainer}>
+                  <span className={classNames('cds--label', styles.dropdownLabel)}>
+                    {t('previewFormIn', 'Preview form in')}
+                  </span>
+                  <Dropdown
+                    id="target-language"
+                    items={languageOptions}
+                    itemToString={(item) => item?.label ?? ''}
+                    label={t('selectLanguage', 'Select language')}
+                    titleText=""
+                    selectedItem={languageOptions.find((opt) => opt.code === selectedLanguageCode)}
+                    onChange={({ selectedItem }) => {
+                      if (selectedItem) setSelectedLanguageCode(selectedItem.code);
+                    }}
+                  />
+                </div>
                 <Button kind="ghost" onClick={handleRenderSchemaChanges} disabled={invalidJsonErrorMessage}>
                   <span>{t('renderChanges', 'Render changes')}</span>
                 </Button>

--- a/src/components/form-editor/form-editor.component.tsx
+++ b/src/components/form-editor/form-editor.component.tsx
@@ -337,20 +337,19 @@ const FormEditorContent: React.FC<TranslationFnProps> = ({ t }) => {
                   </Button>
                 ) : null}
                 <div className={styles.dropdownContainer}>
-                  <span className={classNames('cds--label', styles.dropdownLabel)}>
-                    {t('previewFormIn', 'Preview form in')}
-                  </span>
                   <Dropdown
                     id="target-language"
                     items={languageOptions}
                     itemToString={(item) => item?.label ?? ''}
                     label={t('selectLanguage', 'Select language')}
-                    titleText=""
-                    selectedItem={languageOptions.find((opt) => opt.code === selectedLanguageCode)}
                     onChange={({ selectedItem }) => {
                       if (selectedItem) setSelectedLanguageCode(selectedItem.code);
                     }}
+                    titleText={t('previewFormIn', 'Preview form in')}
+                    selectedItem={languageOptions.find((opt) => opt.code === selectedLanguageCode)}
+                    type="inline"
                   />
+                  
                 </div>
                 <Button kind="ghost" onClick={handleRenderSchemaChanges} disabled={invalidJsonErrorMessage}>
                   <span>{t('renderChanges', 'Render changes')}</span>

--- a/src/components/form-editor/form-editor.scss
+++ b/src/components/form-editor/form-editor.scss
@@ -108,15 +108,10 @@ button {
   align-items: center;
 }
 
-.dropdownContainer {
-  display: flex;
-  align-items: center;
-  :global(.cds--label) {
-    margin-bottom: 0 !important;
-  }
-}
+.dropdown {
+  grid-gap: 0 !important;
 
-.dropdownLabel {
-  margin-right: 0.25rem;
-  white-space: nowrap;
+  :global(.cds--label) {
+    white-space: nowrap;
+  }
 }

--- a/src/components/form-editor/form-editor.scss
+++ b/src/components/form-editor/form-editor.scss
@@ -107,3 +107,16 @@ button {
   display: flex;
   align-items: center;
 }
+
+.dropdownContainer {
+  display: flex;
+  align-items: center;
+  :global(.cds--label) {
+    margin-bottom: 0 !important;
+  }
+}
+
+.dropdownLabel {
+  margin-right: 0.25rem;
+  white-space: nowrap;
+}

--- a/translations/en.json
+++ b/translations/en.json
@@ -164,6 +164,7 @@
   "patientIdentifierTypeHelperText": "Patient identifier type fields must be linked to a patient identifier type",
   "pleaseTryAgain": "Please try again.",
   "preview": "Preview",
+  "previewFormIn": "Preview form in",
   "problemLoadingPreview": "There was a problem loading the schema preview",
   "program": "Program",
   "programState": "Program state",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR adds a label to the language dropdown to make its purpose more clearer. Since its right above the JSON schema editor, its purpose and context is not completely obvious to someone who is not familiar with the translation builder. Previously, it could be mistaken for being a language changer for the entire JSON schema, the label intends to give more context as to what the language dropdown would change the language of. 

## Screenshots
<!-- Required if you are making UI changes. -->
Before:
<img width="838" alt="Screenshot 2025-07-03 at 12 48 10 PM" src="https://github.com/user-attachments/assets/7f1eb5be-b30a-4e96-8b1e-61a56f1591ce" />

After:
<img width="838" alt="Screenshot 2025-07-03 at 1 50 41 PM" src="https://github.com/user-attachments/assets/6276b9ae-363d-4cf0-a0ed-00ba66728ce3" />



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
