### PR TITLE
(feat) O3-4899- Implement backend translation fetching and merging in Translation Builder

### DIFF
--- a/src/hooks/useBackendTranslations.ts
+++ b/src/hooks/useBackendTranslations.ts
@@ -1,0 +1,36 @@
+import useSWR from 'swr';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
+
+interface ClobData {
+  translations: Record<string, string>;
+}
+
+export function useBackendTranslations(formUuid: string | undefined, langCode: string) {
+  const shouldFetch = !!formUuid && langCode !== 'en';
+
+  const { data, error, isLoading } = useSWR<ClobData>(
+    shouldFetch ? `${restBaseUrl}/form/${formUuid}?v=full` : null,
+    async (formUrl) => {
+      const formResponse = await openmrsFetch(formUrl);
+      const form = formResponse?.data;
+
+      if (!form?.resources?.length) return { translations: {} };
+
+      const translationResource = form.resources.find((r: any) => r.name?.endsWith(`translations_${langCode}`));
+
+      if (!translationResource?.valueReference) return { translations: {} };
+
+      const clobUrl = `${restBaseUrl}/clobdata/${translationResource.valueReference}`;
+      const clobResponse = await openmrsFetch(clobUrl);
+      const clobData = clobResponse?.data;
+
+      return clobData ?? { translations: {} };
+    },
+  );
+
+  return {
+    backendTranslations: data?.translations ?? {},
+    backendTranslationError: error,
+    isLoadingTranslations: isLoading,
+  };
+}


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

Overview:
This PR implements the feature to fetch saved translation files from the backend for a selected language and intelligently merge them with the current form schema in the Translation Builder. It ensures that only valid translations (i.e., keys still present in the schema) are retained and used.

This PR covers:

- Fetching translation files from the backend for the selected language.

- Merging backend translations with the current schema using extractTranslationStringsFromSchema.

- Only including translations whose keys are still present in the schema.

- Ignoring outdated keys and using schema strings as fallback for missing translations.


## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4899

## Other
<!-- Anything not covered above -->
