### PR TITLE
(feat) Add discharge summary form template

### DIFF
--- a/src/components/dashboard/dashboard.component.tsx
+++ b/src/components/dashboard/dashboard.component.tsx
@@ -337,6 +337,19 @@ function FormsList({ forms, isValidating, mutate, t }: FormsListProps) {
                       placeholder={t('searchThisList', 'Search this list')}
                     />
                     <Button
+                      kind="secondary"
+                      iconDescription={t('createDischargeSummary', 'Create Discharge Summary')}
+                      renderIcon={() => <Add size={16} />}
+                      size={responsiveSize}
+                      onClick={() =>
+                        navigate({
+                          to: `${window.spaBase}/form-builder/new?template=discharge-summary`,
+                        })
+                      }
+                    >
+                      {t('dischargeSummary', 'Discharge Summary')}
+                    </Button>
+                    <Button
                       kind="primary"
                       iconDescription={t('createNewForm', 'Create a new form')}
                       renderIcon={() => <Add size={16} />}

--- a/src/components/interactive-builder/interactive-builder.component.tsx
+++ b/src/components/interactive-builder/interactive-builder.component.tsx
@@ -79,14 +79,18 @@ const InteractiveBuilder: React.FC<InteractiveBuilderProps> = ({
     return schema || dummySchema;
   }, [onSchemaChange, schema]);
 
-  const launchNewFormModal = useCallback(() => {
-    const schema = initializeSchema();
-    const dispose = showModal('new-form-modal', {
-      closeModal: () => dispose(),
-      schema,
-      onSchemaChange,
-    });
-  }, [onSchemaChange, initializeSchema]);
+  const launchNewFormModal = useCallback(
+    (templateId?: string) => {
+      const schema = initializeSchema();
+      const dispose = showModal('new-form-modal', {
+        closeModal: () => dispose(),
+        schema,
+        onSchemaChange,
+        initialTemplate: templateId,
+      });
+    },
+    [onSchemaChange, initializeSchema],
+  );
 
   const launchAddPageModal = useCallback(() => {
     const dispose = showModal('new-page-modal', {

--- a/src/templates/discharge-summary-template.json
+++ b/src/templates/discharge-summary-template.json
@@ -1,0 +1,451 @@
+{
+  "name": "Discharge Summary",
+  "pages": [
+    {
+      "label": "Patient Admission Information",
+      "sections": [
+        {
+          "label": "Admission Details",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Date of Admission",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "date",
+                "concept": "1640AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+              },
+              "id": "admissionDate",
+              "required": "true"
+            },
+            {
+              "label": "Time of Admission",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "text",
+                "concept": "1641AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+              },
+              "id": "admissionTime"
+            },
+            {
+              "label": "Admitting Department",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "text",
+                "concept": "1642AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+              },
+              "id": "admittingDepartment",
+              "required": "true"
+            },
+            {
+              "label": "Reason for Admission",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "textarea",
+                "concept": "160433AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rows": 4
+              },
+              "id": "reasonForAdmission",
+              "required": "true",
+              "questionInfo": "Provide a brief description of why the patient was admitted"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "Clinical Information",
+      "sections": [
+        {
+          "label": "Diagnoses",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Principal Diagnosis",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "textarea",
+                "concept": "159947AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rows": 3
+              },
+              "id": "principalDiagnosis",
+              "required": "true",
+              "questionInfo": "Primary condition established after study to be chiefly responsible for admission"
+            },
+            {
+              "label": "Secondary Diagnoses",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "textarea",
+                "concept": "159948AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rows": 4
+              },
+              "id": "secondaryDiagnoses",
+              "questionInfo": "Other conditions that coexisted at admission or developed subsequently"
+            },
+            {
+              "label": "Comorbidities",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "textarea",
+                "concept": "162747AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rows": 3
+              },
+              "id": "comorbidities",
+              "questionInfo": "Pre-existing medical conditions"
+            }
+          ]
+        },
+        {
+          "label": "Hospital Course",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Clinical Summary",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "textarea",
+                "concept": "162749AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rows": 6
+              },
+              "id": "clinicalSummary",
+              "required": "true",
+              "questionInfo": "Brief narrative of the patient's hospital stay including significant events"
+            },
+            {
+              "label": "Procedures Performed",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "textarea",
+                "concept": "1651AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rows": 4
+              },
+              "id": "proceduresPerformed",
+              "questionInfo": "List all procedures, surgeries, or interventions performed during hospitalization"
+            },
+            {
+              "label": "Significant Findings",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "textarea",
+                "concept": "162750AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rows": 4
+              },
+              "id": "significantFindings",
+              "questionInfo": "Important test results, imaging findings, or clinical observations"
+            },
+            {
+              "label": "Complications",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "textarea",
+                "concept": "162751AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rows": 3
+              },
+              "id": "complications",
+              "questionInfo": "Any adverse events or complications during hospital stay"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "Discharge Information",
+      "sections": [
+        {
+          "label": "Discharge Details",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Date of Discharge",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "date",
+                "concept": "159752AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+              },
+              "id": "dischargeDate",
+              "required": "true"
+            },
+            {
+              "label": "Time of Discharge",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "text",
+                "concept": "159753AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+              },
+              "id": "dischargeTime"
+            },
+            {
+              "label": "Discharge Disposition",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "select",
+                "concept": "159640AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "answers": [
+                  {
+                    "concept": "160116AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Home"
+                  },
+                  {
+                    "concept": "159642AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Transfer to another facility"
+                  },
+                  {
+                    "concept": "160034AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Transfer to nursing home"
+                  },
+                  {
+                    "concept": "160037AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Transfer to rehabilitation facility"
+                  },
+                  {
+                    "concept": "159641AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Left against medical advice"
+                  },
+                  {
+                    "concept": "160432AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Deceased"
+                  },
+                  {
+                    "concept": "5622AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Other"
+                  }
+                ]
+              },
+              "id": "dischargeDisposition",
+              "required": "true"
+            },
+            {
+              "label": "Discharge Condition",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "select",
+                "concept": "162752AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "answers": [
+                  {
+                    "concept": "162753AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Improved"
+                  },
+                  {
+                    "concept": "162754AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Stable"
+                  },
+                  {
+                    "concept": "162755AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Deteriorated"
+                  },
+                  {
+                    "concept": "162756AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Critical"
+                  }
+                ]
+              },
+              "id": "dischargeCondition",
+              "required": "true"
+            }
+          ]
+        },
+        {
+          "label": "Medications",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Discharge Medications",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "textarea",
+                "concept": "162757AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rows": 6
+              },
+              "id": "dischargeMedications",
+              "required": "true",
+              "questionInfo": "List all medications patient should continue after discharge (include dosage, frequency, duration)"
+            },
+            {
+              "label": "Medications Discontinued",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "textarea",
+                "concept": "162758AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rows": 3
+              },
+              "id": "medicationsDiscontinued",
+              "questionInfo": "Medications stopped during hospitalization"
+            },
+            {
+              "label": "Medication Allergies/Adverse Reactions",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "textarea",
+                "concept": "121764AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rows": 3
+              },
+              "id": "medicationAllergies",
+              "questionInfo": "Document any medication allergies or adverse reactions"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "Post-Discharge Care",
+      "sections": [
+        {
+          "label": "Follow-up Care",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Follow-up Instructions",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "textarea",
+                "concept": "162759AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rows": 5
+              },
+              "id": "followUpInstructions",
+              "required": "true",
+              "questionInfo": "Detailed instructions for patient care after discharge"
+            },
+            {
+              "label": "Follow-up Appointment Date",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "date",
+                "concept": "5096AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+              },
+              "id": "followUpDate"
+            },
+            {
+              "label": "Follow-up Provider/Clinic",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "text",
+                "concept": "162760AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+              },
+              "id": "followUpProvider",
+              "questionInfo": "Name and contact of provider/clinic for follow-up"
+            },
+            {
+              "label": "Dietary Restrictions",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "textarea",
+                "concept": "162761AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rows": 3
+              },
+              "id": "dietaryRestrictions",
+              "questionInfo": "Special diet instructions or restrictions"
+            },
+            {
+              "label": "Activity Restrictions",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "textarea",
+                "concept": "162762AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rows": 3
+              },
+              "id": "activityRestrictions",
+              "questionInfo": "Physical activity limitations or restrictions"
+            },
+            {
+              "label": "Warning Signs",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "textarea",
+                "concept": "162763AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rows": 4
+              },
+              "id": "warningSigns",
+              "required": "true",
+              "questionInfo": "Symptoms or signs that require immediate medical attention"
+            }
+          ]
+        },
+        {
+          "label": "Patient Education",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Patient Education Provided",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "textarea",
+                "concept": "162764AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rows": 4
+              },
+              "id": "patientEducation",
+              "questionInfo": "Topics covered during patient education (disease management, medication use, etc.)"
+            },
+            {
+              "label": "Patient Understanding Confirmed",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "radio",
+                "concept": "162765AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "answers": [
+                  {
+                    "concept": "1065AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "Yes"
+                  },
+                  {
+                    "concept": "1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "label": "No"
+                  }
+                ]
+              },
+              "id": "patientUnderstanding",
+              "questionInfo": "Confirm patient/family demonstrates understanding of discharge instructions"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "label": "Provider Information",
+      "sections": [
+        {
+          "label": "Provider Details",
+          "isExpanded": "true",
+          "questions": [
+            {
+              "label": "Discharging Physician Name",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "text",
+                "concept": "162766AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+              },
+              "id": "dischargingPhysician",
+              "required": "true"
+            },
+            {
+              "label": "Attending Physician Name",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "text",
+                "concept": "162767AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+              },
+              "id": "attendingPhysician"
+            },
+            {
+              "label": "Additional Notes",
+              "type": "obs",
+              "questionOptions": {
+                "rendering": "textarea",
+                "concept": "162768AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "rows": 4
+              },
+              "id": "additionalNotes",
+              "questionInfo": "Any additional information relevant to patient care"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "processor": "EncounterFormProcessor",
+  "uuid": "discharge-summary-form-v1",
+  "encounterType": "",
+  "referencedForms": [],
+  "version": "1.0",
+  "description": "Comprehensive discharge summary form for documenting patient hospital stay and post-discharge care instructions"
+}

--- a/src/utils/form-templates.ts
+++ b/src/utils/form-templates.ts
@@ -1,0 +1,51 @@
+import dischargeSummaryTemplate from '../templates/discharge-summary-template.json';
+import type { Schema } from '@types';
+
+export interface FormTemplate {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  schema: Schema;
+}
+
+/**
+ * Available form templates that users can use to quickly create forms
+ */
+export const formTemplates: FormTemplate[] = [
+  {
+    id: 'discharge-summary',
+    name: 'Discharge Summary',
+    description:
+      'Comprehensive discharge summary form for documenting patient hospital stay and post-discharge care instructions',
+    category: 'Clinical',
+    schema: dischargeSummaryTemplate as Schema,
+  },
+  // Add more templates here as needed
+];
+
+/**
+ * Get a form template by ID
+ * @param templateId The ID of the template to retrieve
+ * @returns The form template or undefined if not found
+ */
+export function getFormTemplate(templateId: string): FormTemplate | undefined {
+  return formTemplates.find((template) => template.id === templateId);
+}
+
+/**
+ * Get all form templates for a specific category
+ * @param category The category to filter by
+ * @returns Array of form templates in the specified category
+ */
+export function getFormTemplatesByCategory(category: string): FormTemplate[] {
+  return formTemplates.filter((template) => template.category === category);
+}
+
+/**
+ * Get all available template categories
+ * @returns Array of unique category names
+ */
+export function getTemplateCategories(): string[] {
+  return [...new Set(formTemplates.map((template) => template.category))];
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,7 @@
       "@tools/*": ["./tools/*"],
       "@constants": ["./src/constants"],
       "@resources/*": ["./src/resources/*"],
+      "@utils/*": ["./src/utils/*"],
       "@openmrs/*": ["./node_modules/@openmrs/*"]
     }
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ config.overrides.resolve = {
     '@resources': path.resolve(__dirname, 'src/resources/'),
     '@tools': path.resolve(__dirname, 'tools/'),
     '@constants$': path.resolve(__dirname, 'src/constants.ts'),
+    '@utils': path.resolve(__dirname, 'src/utils/'),
   },
 };
 module.exports = config;


### PR DESCRIPTION
- Implement template selection system in new form modal
- Add comprehensive discharge summary template with medical sections
- Create reusable form template utilities
- Update TypeScript and webpack config for template support

This allows users to quickly create discharge summary forms from a predefined template instead of building from scratch.

Fixes #554

## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
