### PR TITLE
(fix) Align forms dashboard search bar height with the create button

### DIFF
--- a/src/components/dashboard/dashboard.component.tsx
+++ b/src/components/dashboard/dashboard.component.tsx
@@ -404,6 +404,7 @@ function FormsList({ forms, isValidating, mutate, t }: FormsListProps) {
                   <TableToolbarContent className={styles.headerContainer}>
                     <TableToolbarSearch
                       expanded
+                      size={responsiveSize}
                       className={styles.searchbox}
                       onChange={handleSearch}
                       placeholder={t('searchThisList', 'Search this list')}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.

## Summary

The "Search this list" field on the forms dashboard rendered taller than the adjacent "Create a new form" button, overflowing the toolbar and overlapping the table header row.

The search had no explicit `size`, so it fell back to Carbon's `TableToolbarSearch` default of `size="lg"` (48px), while the button is `size={responsiveSize}` (`sm` = 32px on desktop). `TableToolbarSearch` does not inherit size from the parent `<TableToolbar size=...>` — that only adds a class to the toolbar wrapper, and Carbon keys the small styling on the search's own `--search--sm` class. The two controls lined up only by coincidence with whatever Carbon version the app shell shipped; a newer Carbon singleton exposed the mismatch.

The fix passes `size={responsiveSize}` to the search so both controls share the same responsive size (`sm` on desktop, `lg` on tablet) regardless of the Carbon version in use.

## Screenshots

<!-- before/after -->

## Related Issue

## Other

Verified locally against a backend at `http://localhost`: the search bar and the "Create a new form" button are now equal height and the table header is no longer overlapped.

No test added: the only thing to assert would be that the search carries the `cds--search--sm` class, which is a brittle implementation-detail assertion. Verified visually instead.
