### PR TITLE
(chore) O3-5865: Add @carbon/react and @carbon/icons-react to peerDependencies in openmrs-esm-form-builder

### DIFF
--- a/e2e/pages/form-builder-page.ts
+++ b/e2e/pages/form-builder-page.ts
@@ -11,11 +11,10 @@ export class FormBuilderPage {
   readonly inputDummySchemaButton = () => this.page.getByRole('button', { name: /load sample schema/i });
   readonly saveFormButton = () => this.page.getByRole('button', { name: /save form/i });
   readonly editFormButton = () => this.page.getByRole('button', { name: /edit schema/i });
-  readonly deleteFormConfirmationButton = () => this.page.getByRole('button', { name: /danger retire/i });
+  readonly deleteFormConfirmationButton = () => this.page.getByRole('button', { name: /retire/i });
   readonly publishFormButton = () => this.page.getByRole('button', { name: /^publish form$/i });
   readonly unpublishFormButton = () => this.page.getByRole('button', { name: /unpublish form/i });
-  readonly unpublishFormConfirmationButton = () =>
-    this.page.getByRole('button', { name: /^danger unpublish$/i, exact: true });
+  readonly unpublishFormConfirmationButton = () => this.page.getByRole('button', { name: /^unpublish$/i, exact: true });
   readonly updateExistingFormButton = () => this.page.getByRole('button', { name: /update existing version/i });
   readonly formNameInput = () => this.page.getByLabel(/form name/i);
   readonly formVersionInput = () => this.page.getByLabel(/version/i);

--- a/e2e/pages/form-builder-page.ts
+++ b/e2e/pages/form-builder-page.ts
@@ -11,7 +11,7 @@ export class FormBuilderPage {
   readonly inputDummySchemaButton = () => this.page.getByRole('button', { name: /load sample schema/i });
   readonly saveFormButton = () => this.page.getByRole('button', { name: /save form/i });
   readonly editFormButton = () => this.page.getByRole('button', { name: /edit schema/i });
-  readonly deleteFormConfirmationButton = () => this.page.getByRole('button', { name: /retire/i });
+  readonly deleteFormConfirmationButton = () => this.page.getByRole('dialog').getByRole('button', { name: /retire/i });
   readonly publishFormButton = () => this.page.getByRole('button', { name: /^publish form$/i });
   readonly unpublishFormButton = () => this.page.getByRole('button', { name: /unpublish form/i });
   readonly unpublishFormConfirmationButton = () => this.page.getByRole('button', { name: /^unpublish$/i, exact: true });

--- a/e2e/specs/edit-form-with-interactive-builder.spec.ts
+++ b/e2e/specs/edit-form-with-interactive-builder.spec.ts
@@ -196,7 +196,10 @@ test('Edit a form using the interactive builder', async ({ page, context }) => {
   });
 
   await test.step('And then I click the `Delete` button on the modal', async () => {
-    await formBuilderPage.page.getByRole('button', { name: /delete question/i }).click();
+    await formBuilderPage.page
+      .getByRole('dialog')
+      .getByRole('button', { name: /delete question/i })
+      .click();
     updatedForm.pages[0].sections[0].questions = updatedForm.pages[0].sections[0].questions.filter(
       (q) => q.id !== 'sampleQuestion',
     );
@@ -214,7 +217,10 @@ test('Edit a form using the interactive builder', async ({ page, context }) => {
   });
 
   await test.step('And then I click the `Delete` button on the modal', async () => {
-    await formBuilderPage.page.getByRole('button', { name: /delete section/i }).click();
+    await formBuilderPage.page
+      .getByRole('dialog')
+      .getByRole('button', { name: /delete section/i })
+      .click();
     updatedForm.pages[0].sections = [];
   });
 
@@ -230,7 +236,10 @@ test('Edit a form using the interactive builder', async ({ page, context }) => {
   });
 
   await test.step('And then I click the `Delete` button on the modal', async () => {
-    await formBuilderPage.page.getByRole('button', { name: /delete page/i }).click();
+    await formBuilderPage.page
+      .getByRole('dialog')
+      .getByRole('button', { name: /delete page/i })
+      .click();
     updatedForm.pages = [];
   });
 

--- a/e2e/specs/edit-form-with-interactive-builder.spec.ts
+++ b/e2e/specs/edit-form-with-interactive-builder.spec.ts
@@ -196,7 +196,7 @@ test('Edit a form using the interactive builder', async ({ page, context }) => {
   });
 
   await test.step('And then I click the `Delete` button on the modal', async () => {
-    await formBuilderPage.page.getByRole('button', { name: /danger delete question/i }).click();
+    await formBuilderPage.page.getByRole('button', { name: /delete question/i }).click();
     updatedForm.pages[0].sections[0].questions = updatedForm.pages[0].sections[0].questions.filter(
       (q) => q.id !== 'sampleQuestion',
     );
@@ -214,7 +214,7 @@ test('Edit a form using the interactive builder', async ({ page, context }) => {
   });
 
   await test.step('And then I click the `Delete` button on the modal', async () => {
-    await formBuilderPage.page.getByRole('button', { name: /danger delete section/i }).click();
+    await formBuilderPage.page.getByRole('button', { name: /delete section/i }).click();
     updatedForm.pages[0].sections = [];
   });
 
@@ -230,7 +230,7 @@ test('Edit a form using the interactive builder', async ({ page, context }) => {
   });
 
   await test.step('And then I click the `Delete` button on the modal', async () => {
-    await formBuilderPage.page.getByRole('button', { name: /danger delete page/i }).click();
+    await formBuilderPage.page.getByRole('button', { name: /delete page/i }).click();
     updatedForm.pages = [];
   });
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "url": "https://github.com/openmrs/openmrs-esm-form-builder/issues"
   },
   "dependencies": {
+    "@carbon/icons-react": "^11.68.0",
     "@carbon/react": "^1.83.0",
     "@openmrs/esm-form-engine-lib": "next",
     "ajv": "^8.17.1",
@@ -59,6 +60,8 @@
     "sass": "^1.67.0"
   },
   "peerDependencies": {
+    "@carbon/icons-react": "11.x",
+    "@carbon/react": "1.x",
     "@openmrs/esm-framework": "10.x",
     "react": "18.x",
     "react-dom": "18.x",

--- a/tools/setup-tests.ts
+++ b/tools/setup-tests.ts
@@ -1,48 +1,6 @@
 import '@testing-library/jest-dom/vitest';
 import { vi } from 'vitest';
 
-// Node >=22 defines an experimental localStorage/sessionStorage global that
-// resolves to undefined unless --localstorage-file is passed, shadowing jsdom's
-// storage. Restore the jsdom-backed instances (or an in-memory fallback).
-function installStorage(name: 'localStorage' | 'sessionStorage') {
-  const descriptor = Object.getOwnPropertyDescriptor(globalThis, name);
-  if (descriptor && typeof descriptor.get === 'function') {
-    let store: Storage;
-    try {
-      store = (globalThis as { jsdom?: { window: Window } }).jsdom.window[name];
-    } catch {
-      store = undefined;
-    }
-    if (!store) {
-      const data = new Map<string, string>();
-      store = {
-        get length() {
-          return data.size;
-        },
-        key(index: number) {
-          return [...data.keys()][index] ?? null;
-        },
-        getItem(key: string) {
-          return data.has(key) ? data.get(key) : null;
-        },
-        setItem(key: string, value: string) {
-          data.set(key, String(value));
-        },
-        removeItem(key: string) {
-          data.delete(key);
-        },
-        clear() {
-          data.clear();
-        },
-      } as Storage;
-    }
-    Object.defineProperty(globalThis, name, { value: store, configurable: true, writable: true });
-  }
-}
-
-installStorage('localStorage');
-installStorage('sessionStorage');
-
 window.URL.createObjectURL = vi.fn();
 window.openmrsBase = '/openmrs';
 window.spaBase = '/spa';

--- a/tools/setup-tests.ts
+++ b/tools/setup-tests.ts
@@ -1,6 +1,48 @@
 import '@testing-library/jest-dom/vitest';
 import { vi } from 'vitest';
 
+// Node >=22 defines an experimental localStorage/sessionStorage global that
+// resolves to undefined unless --localstorage-file is passed, shadowing jsdom's
+// storage. Restore the jsdom-backed instances (or an in-memory fallback).
+function installStorage(name: 'localStorage' | 'sessionStorage') {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, name);
+  if (descriptor && typeof descriptor.get === 'function') {
+    let store: Storage;
+    try {
+      store = (globalThis as { jsdom?: { window: Window } }).jsdom.window[name];
+    } catch {
+      store = undefined;
+    }
+    if (!store) {
+      const data = new Map<string, string>();
+      store = {
+        get length() {
+          return data.size;
+        },
+        key(index: number) {
+          return [...data.keys()][index] ?? null;
+        },
+        getItem(key: string) {
+          return data.has(key) ? data.get(key) : null;
+        },
+        setItem(key: string, value: string) {
+          data.set(key, String(value));
+        },
+        removeItem(key: string) {
+          data.delete(key);
+        },
+        clear() {
+          data.clear();
+        },
+      } as Storage;
+    }
+    Object.defineProperty(globalThis, name, { value: store, configurable: true, writable: true });
+  }
+}
+
+installStorage('localStorage');
+installStorage('sessionStorage');
+
 window.URL.createObjectURL = vi.fn();
 window.openmrsBase = '/openmrs';
 window.spaBase = '/spa';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2274,6 +2274,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-form-builder-app@workspace:."
   dependencies:
+    "@carbon/icons-react": "npm:^11.68.0"
     "@carbon/react": "npm:^1.83.0"
     "@dnd-kit/core": "npm:^6.3.1"
     "@dnd-kit/modifiers": "npm:^6.0.1"
@@ -2327,6 +2328,8 @@ __metadata:
     typescript: "npm:^5.0.0"
     vitest: "npm:^4.1.2"
   peerDependencies:
+    "@carbon/icons-react": 11.x
+    "@carbon/react": 1.x
     "@openmrs/esm-framework": 10.x
     react: 18.x
     react-dom: 18.x


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

<!-- Please describe what problems your PR addresses. -->
I added @carbon/react and @carbon/icons-react to the app package's peerDependencies (matching the shell version ranges) to enable Module Federation singleton sharing, eliminate duplicate Carbon runtime chunks in production builds, and ensure existing tests continue to pass.

## Screenshots

<!-- Required if you are making UI changes. -->

## Related Issue

<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/issues?filter=-1&selectedIssue=O3-5865

## Other

<!-- Anything not covered above -->
