### PR TITLE
(fix) Prevent invalid group renderings on obs questions

### DIFF
--- a/src/components/interactive-builder/modals/question/question-form/question/question.component.tsx
+++ b/src/components/interactive-builder/modals/question/question-form/question/question.component.tsx
@@ -52,18 +52,15 @@ const Question: React.FC<QuestionProps> = ({ checkIfQuestionIdExists }) => {
       setFormField((prevFormField) => {
         const hasPreviousRenderingType = prevFormField?.questionOptions?.rendering;
         if (hasPreviousRenderingType) {
-          const isQuestionTypeObs = newQuestionType === 'obs' ? true : false;
-          if (!isQuestionTypeObs) {
-            const isRenderingTypeValidForQuestionType =
-              questionTypes.includes(newQuestionType as keyof typeof renderTypeOptions) &&
-              renderTypeOptions[newQuestionType]?.includes(prevFormField.questionOptions.rendering as RenderType);
-            if (!isRenderingTypeValidForQuestionType) {
-              return {
-                ...prevFormField,
-                questionOptions: { ...prevFormField.questionOptions, rendering: null },
-                type: newQuestionType,
-              };
-            }
+          const isRenderingTypeValidForQuestionType =
+            questionTypes.includes(newQuestionType as keyof typeof renderTypeOptions) &&
+            renderTypeOptions[newQuestionType]?.includes(prevFormField.questionOptions.rendering as RenderType);
+          if (!isRenderingTypeValidForQuestionType) {
+            return {
+              ...prevFormField,
+              questionOptions: { ...prevFormField.questionOptions, rendering: null },
+              type: newQuestionType,
+            };
           }
         }
         return {
@@ -162,9 +159,7 @@ const Question: React.FC<QuestionProps> = ({ checkIfQuestionIdExists }) => {
         {!formField.questionOptions?.rendering && (
           <SelectItem text={t('chooseRenderingType', 'Choose a rendering type')} value="" />
         )}
-        {formField.type &&
-        formField.type !== 'obs' &&
-        questionTypes.includes(formField.type as keyof typeof renderTypeOptions)
+        {formField.type && questionTypes.includes(formField.type as keyof typeof renderTypeOptions)
           ? renderTypeOptions[formField?.type].map((type, key) => (
               <SelectItem key={`${type}-${key}`} text={type} value={type} />
             ))

--- a/src/components/interactive-builder/modals/question/question-form/question/question.test.tsx
+++ b/src/components/interactive-builder/modals/question/question-form/question/question.test.tsx
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event';
 import Question from './question.component';
 import { FormFieldProvider } from '../../form-field-context';
 import type { FormField } from '@openmrs/esm-form-engine-lib';
-import { renderingTypes } from '@constants';
+import { renderTypeOptions } from '@constants';
 
 const initialFormField: FormField = {
   id: 'testId',
@@ -293,7 +293,7 @@ describe('Question Component', () => {
     expect(options[0]).toHaveTextContent('select');
   });
 
-  it('should show all rendering types for obs question type', async () => {
+  it('should not show group rendering types for obs question type', () => {
     renderWithFormFieldProvider(<Question checkIfQuestionIdExists={checkIfQuestionIdExists} />, {
       formField: { ...initialFormField, type: 'obs' },
     });
@@ -306,13 +306,30 @@ describe('Question Component', () => {
       (option) => option.value && option.value !== '',
     );
 
-    expect(options).toHaveLength(renderingTypes.length);
+    expect(options).toHaveLength(renderTypeOptions.obs.length);
 
     const optionTexts = options.map((option) => option.textContent);
 
-    renderingTypes.forEach((renderType) => {
+    renderTypeOptions.obs.forEach((renderType) => {
       expect(optionTexts).toContain(renderType);
     });
+    expect(optionTexts).not.toContain('group');
+    expect(optionTexts).not.toContain('repeating');
+  });
+
+  it('clears a group rendering when the question type changes to obs', async () => {
+    const user = userEvent.setup();
+    renderWithFormFieldProvider(<Question checkIfQuestionIdExists={checkIfQuestionIdExists} />, {
+      formField: {
+        ...initialFormField,
+        type: 'obsGroup',
+        questionOptions: { rendering: 'repeating' },
+      },
+    });
+
+    await user.selectOptions(screen.getByLabelText(/question type/i), 'obs');
+
+    expect(screen.getByLabelText(/rendering type/i)).toHaveValue('');
   });
 
   it('should load question info from the form field object', () => {

--- a/src/components/interactive-builder/modals/question/question-form/rendering-types/rendering-type.component.tsx
+++ b/src/components/interactive-builder/modals/question/question-form/rendering-types/rendering-type.component.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Date, Markdown, Number, SelectAnswers, Text, TextArea, Toggle, UiSelectExtended } from './inputs';
 import { useFormField } from '../../form-field-context';
 import type { RenderType } from '@openmrs/esm-form-engine-lib';
-import { renderTypeOptions, renderingTypes } from '@constants';
+import { renderTypeOptions } from '@constants';
 
 const componentMap: Partial<Record<RenderType, React.FC>> = {
   number: Number,
@@ -21,8 +21,7 @@ const componentMap: Partial<Record<RenderType, React.FC>> = {
 const RenderTypeComponent: React.FC = () => {
   const { formField } = useFormField();
   // Get allowed rendering types based on formField.type
-  const allowedRenderingTypes =
-    formField.type && formField.type !== 'obs' ? renderTypeOptions[formField.type] : renderingTypes;
+  const allowedRenderingTypes = formField.type ? renderTypeOptions[formField.type] : [];
 
   // Only get component if rendering type is allowed. Exception is program state because selecting the states is also implemented in the SelectAnswers component
   const Component =

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -50,7 +50,7 @@ export const renderTypeOptions: Record<QuestionType, Array<RenderType>> = {
   encounterLocation: ['ui-select-extended'],
   encounterProvider: ['ui-select-extended'],
   encounterRole: ['ui-select-extended'],
-  obs: renderingTypes,
+  obs: renderingTypes.filter((renderingType) => renderingType !== 'group' && renderingType !== 'repeating'),
   obsGroup: ['group', 'repeating'],
   personAttribute: ['text', 'select', 'date', 'radio', 'checkbox', 'textarea', 'toggle', 'ui-select-extended'],
   testOrder: ['group', 'repeating'],


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done and includes a conventional commit label.
- [x] This bug fix enforces the existing Form Engine schema constraints; no design changes are required.
- [x] My work includes tests and is validated by existing tests.

## Summary

- exclude `group` and `repeating` from the rendering types offered for plain `obs` questions
- use the per-question-type allow-list consistently for both the selector and rendering-specific controls
- clear a group rendering when an `obsGroup` or `testOrder` question is changed to `obs`, preventing the invalid value from carrying over
- add regression coverage for the available options and the question-type transition

This prevents the builder from creating plain `obs` schemas that cause the Form Engine preview to infinitely nest Repeat **Add** buttons.

## Screenshots

Not applicable. This change removes invalid options from an existing select without altering layout or styling; the resulting option list and transition behavior are covered by unit tests.

## Related Issue

Fixes #1297

## Other

### Testing

- `yarn test` — 20 test files, 111 tests passed
- `yarn verify` — lint, TypeScript, and coverage passed
- `yarn build` — passed (existing asset-size warning only)
