### PR TITLE
(feat) O3-5945: Add annotation to the available field types

### DIFF
--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -42,6 +42,7 @@ const allowedFieldTypes: Array<RenderType> = [
   'markdown',
   'extension-widget',
   'select-concept-answers',
+  'annotation',
 ];
 
 export const configSchema = {
@@ -147,7 +148,7 @@ export const configSchema = {
       _elements: {
         _type: Type.String,
       },
-      _default: ['file'],
+      _default: ['file', 'annotation'],
     },
   },
   enableFormValidation: {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -42,6 +42,7 @@ export const renderingTypes: Array<RenderType> = [
   'markdown',
   'extension-widget',
   'select-concept-answers',
+  'annotation',
 ];
 
 export const renderTypeOptions: Record<QuestionType, Array<RenderType>> = {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. PR title uses the (feat) conventional commit label.
- [x] My work is based this PR [https://github.com/openmrs/openmrs-esm-form-engine-lib/pull/795](url), No UI changes 
- [ ] My work includes tests or is validated by existing tests.

## Summary

Part of the "Draw on a Body Diagram" epic ([O3-5941](https://openmrs.atlassian.net/browse/O3-5941)). Clinicians currently have no way to annotate body diagrams inside clinical forms.

This PR adds the option to select "Annotation" as a rendering type if the question type is selected as Obs. Annotation also works as a complex obs-like "file" input field does

Changes:

- Add annotation as a selectable option to renderingTypes
- Added to the allowed field types config

## Screenshots

<img width="1036" height="449" alt="image" src="https://github.com/user-attachments/assets/1b55d4d4-6733-4aba-afca-ef4c526c2d63" />

## Related Issue

https://openmrs.atlassian.net/browse/O3-5945

## Other

- Epic: [O3-5941 — Draw on a Body Diagram](https://openmrs.atlassian.net/browse/O3-5941)
- Wiki: https://openmrs.atlassian.net/wiki/x/EQBsTQ
- Talk thread: https://talk.openmrs.org/t/o3-draw-on-a-body-diagram-new-implementation/49754

[O3-5941]: https://openmrs.atlassian.net/browse/O3-5941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
