### PR TITLE
(fix) Use framework modal for saving forms

### DIFF
--- a/e2e/specs/create-form-with-interactive-builder.spec.ts
+++ b/e2e/specs/create-form-with-interactive-builder.spec.ts
@@ -5,11 +5,13 @@ import { FormBuilderPage } from '../pages';
 import { type Form } from '@types';
 
 let form: Form = null;
+
 test.beforeEach(async ({ api }) => {
   form = await createForm(api, true);
   const valueReference = await createValueReference(api);
   await addFormResources(api, valueReference, form.uuid);
 });
+
 let formUuid = '';
 const formDetails = {
   name: 'Covid-19 Screening',
@@ -53,6 +55,15 @@ const formDetails = {
   description: 'A test form for recording COVID-19 screening information',
 };
 
+test.afterEach(async ({ api }) => {
+  if (formUuid) {
+    await deleteForm(api, formUuid);
+  }
+  if (form) {
+    await deleteForm(api, form.uuid);
+  }
+});
+
 test('Create a form using the interactive builder', async ({ page, context }) => {
   const formBuilderPage = new FormBuilderPage(page);
 
@@ -94,7 +105,8 @@ test('Create a form using the interactive builder', async ({ page, context }) =>
   });
 
   await test.step('And then I fill in the page title', async () => {
-    await formBuilderPage.pageNameInput().fill(formDetails.pages[0].label);
+    const input = formBuilderPage.pageNameInput();
+    await input.fill(formDetails.pages[0].label);
   });
 
   await test.step('And then I click on `Save`', async () => {
@@ -203,7 +215,7 @@ test('Create a form using the interactive builder', async ({ page, context }) =>
 
   await test.step('And then I select the form to be referenced', async () => {
     await formBuilderPage.selectFormDropdown().click();
-    await formBuilderPage.page.getByRole('option', { name: 'A sample test form ' }).click();
+    await formBuilderPage.page.getByRole('option', { name: form.name, exact: true }).click();
   });
 
   await test.step('And then I select the page to be referenced', async () => {
@@ -291,13 +303,4 @@ test('Create a form using the interactive builder', async ({ page, context }) =>
     const editFormPageURL = page.url();
     formUuid = editFormPageURL.split('/').slice(-1)[0];
   });
-});
-
-test.afterEach(async ({ api }) => {
-  if (formUuid) {
-    await deleteForm(api, formUuid);
-  }
-  if (form) {
-    await deleteForm(api, form.uuid);
-  }
 });

--- a/e2e/specs/create-form-with-interactive-builder.spec.ts
+++ b/e2e/specs/create-form-with-interactive-builder.spec.ts
@@ -105,8 +105,8 @@ test('Create a form using the interactive builder', async ({ page, context }) =>
   });
 
   await test.step('And then I fill in the page title', async () => {
-    const input = formBuilderPage.pageNameInput();
-    await input.fill(formDetails.pages[0].label);
+    // eslint-disable-next-line playwright/prefer-locator -- pageNameInput() returns a locator.
+    await formBuilderPage.pageNameInput().fill(formDetails.pages[0].label);
   });
 
   await test.step('And then I click on `Save`', async () => {

--- a/e2e/specs/edit-form-with-interactive-builder.spec.ts
+++ b/e2e/specs/edit-form-with-interactive-builder.spec.ts
@@ -39,10 +39,17 @@ let updatedForm = {
   version: '1',
   description: 'This is test description',
 };
+
 test.beforeEach(async ({ api }) => {
   form = await createForm(api, false, formDetails);
   const valueReference = await createValueReference(api);
   await addFormResources(api, valueReference, form.uuid);
+});
+
+test.afterEach(async ({ api }) => {
+  if (form) {
+    await deleteForm(api, form.uuid);
+  }
 });
 
 test('Edit a form using the interactive builder', async ({ page, context }) => {
@@ -237,13 +244,8 @@ test('Edit a form using the interactive builder', async ({ page, context }) => {
   await test.step('Then I should get a success message and the page should be deleted', async () => {
     await expect(formBuilderPage.page.getByText(/page deleted/i)).toBeVisible();
     await expect(formBuilderPage.page.getByRole('heading', { level: 1, name: /an edited page/i })).toHaveCount(0);
-    const formTextContent = await formBuilderPage.schemaEditorContent().textContent();
-    expect(JSON.parse(formTextContent)).toEqual(updatedForm);
+    await expect
+      .poll(async () => JSON.parse(await formBuilderPage.schemaEditorContent().textContent()))
+      .toEqual(updatedForm);
   });
-});
-
-test.afterEach(async ({ api }) => {
-  if (form) {
-    await deleteForm(api, form.uuid);
-  }
 });

--- a/src/components/action-buttons/action-buttons.component.tsx
+++ b/src/components/action-buttons/action-buttons.component.tsx
@@ -137,6 +137,7 @@ function ActionButtons({
             form,
             schema,
             formUuid,
+            closeModal: () => disposeSaveModal.current?.(),
             onSavingChange: setIsSavingForm,
           });
         }}

--- a/src/components/action-buttons/action-buttons.component.tsx
+++ b/src/components/action-buttons/action-buttons.component.tsx
@@ -1,8 +1,7 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useState, useEffect, useRef } from 'react';
 import { Button, InlineLoading } from '@carbon/react';
 import { useParams } from 'react-router-dom';
 import { showModal, showSnackbar, useConfig } from '@openmrs/esm-framework';
-import SaveFormModal from '../interactive-builder/modals/save-form/save-form.modal';
 import { handleFormValidation } from '@resources/form-validator.resource';
 import { publishForm, unpublishForm } from '@resources/forms.resource';
 import { useForm } from '@hooks/useForm';
@@ -50,6 +49,9 @@ function ActionButtons({
   const { formUuid } = useParams<{ formUuid?: string }>();
   const { form, mutate } = useForm(formUuid);
   const [status, setStatus] = useState<Status>('idle');
+  const [isSavingForm, setIsSavingForm] = useState(false);
+  const disposeSaveModal = useRef<ReturnType<typeof showModal>>();
+  useEffect(() => () => disposeSaveModal.current?.(), []);
   const { dataTypeToRenderingMap, enableFormValidation } = useConfig<ConfigObject>();
 
   async function handlePublish() {
@@ -126,7 +128,21 @@ function ActionButtons({
 
   return (
     <div className={styles.actionButtons}>
-      <SaveFormModal form={form} schema={schema} />
+      <Button
+        disabled={!schema || isSavingForm}
+        kind="primary"
+        onClick={() => {
+          disposeSaveModal.current?.();
+          disposeSaveModal.current = showModal('save-form-modal', {
+            form,
+            schema,
+            formUuid,
+            onSavingChange: setIsSavingForm,
+          });
+        }}
+      >
+        {t('saveForm', 'Save form')}
+      </Button>
 
       <>
         {form && enableFormValidation && (

--- a/src/components/interactive-builder/modals/save-form/save-form.modal.tsx
+++ b/src/components/interactive-builder/modals/save-form/save-form.modal.tsx
@@ -223,7 +223,7 @@ const SaveFormModal: React.FC<SaveFormModalProps> = ({ form, schema, formUuid, c
     <>
       <ModalHeader closeModal={close} title={t('saveFormToServer', 'Save form to server')} />
       <ModalBody>
-        <Form id="save-form" onSubmit={handleSubmit} className={styles.saveFormBody}>
+        <Form id="save-form" onSubmit={handleSubmit}>
           <p>
             {t(
               'saveExplainerText',

--- a/src/components/interactive-builder/modals/save-form/save-form.modal.tsx
+++ b/src/components/interactive-builder/modals/save-form/save-form.modal.tsx
@@ -42,11 +42,11 @@ interface SaveFormModalProps {
   form: FormGroupData;
   schema: Schema;
   formUuid?: string;
-  close: () => void;
+  closeModal: () => void;
   onSavingChange?: (isSaving: boolean) => void;
 }
 
-const SaveFormModal: React.FC<SaveFormModalProps> = ({ form, schema, formUuid, close, onSavingChange }) => {
+const SaveFormModal: React.FC<SaveFormModalProps> = ({ form, schema, formUuid, closeModal, onSavingChange }) => {
   const { t } = useTranslation();
   const { encounterTypes } = useEncounterTypes();
   const { mutate } = useForm(formUuid);
@@ -116,7 +116,7 @@ const SaveFormModal: React.FC<SaveFormModalProps> = ({ form, schema, formUuid, c
               t('saveSuccessMessage', 'was created successfully. It is now visible on the Forms dashboard.'),
           });
           clearDraftFormSchema();
-          close();
+          closeModal();
           await mutate();
 
           navigate({
@@ -174,7 +174,7 @@ const SaveFormModal: React.FC<SaveFormModalProps> = ({ form, schema, formUuid, c
             isLowContrast: true,
             subtitle: form?.name + ' ' + t('saveSuccess', 'was updated successfully'),
           });
-          close();
+          closeModal();
           await mutate();
         } catch (error) {
           if (error instanceof Error) {
@@ -195,7 +195,7 @@ const SaveFormModal: React.FC<SaveFormModalProps> = ({ form, schema, formUuid, c
   if (saveState === null) {
     return (
       <>
-        <ModalHeader closeModal={close} title={t('saveConfirmation', 'Save or Update form')} />
+        <ModalHeader closeModal={closeModal} title={t('saveConfirmation', 'Save or Update form')} />
         <ModalBody>
           <p>
             {t(
@@ -211,7 +211,7 @@ const SaveFormModal: React.FC<SaveFormModalProps> = ({ form, schema, formUuid, c
           <Button kind={'primary'} onClick={() => setSaveState('newVersion')}>
             {t('saveAsNewForm', 'Save as a new form')}
           </Button>
-          <Button kind={'secondary'} onClick={close}>
+          <Button kind={'secondary'} onClick={closeModal}>
             {t('close', 'Close')}
           </Button>
         </ModalFooter>
@@ -221,7 +221,7 @@ const SaveFormModal: React.FC<SaveFormModalProps> = ({ form, schema, formUuid, c
 
   return (
     <>
-      <ModalHeader closeModal={close} title={t('saveFormToServer', 'Save form to server')} />
+      <ModalHeader closeModal={closeModal} title={t('saveFormToServer', 'Save form to server')} />
       <ModalBody>
         <Form id="save-form" onSubmit={handleSubmit}>
           <p>
@@ -300,7 +300,7 @@ const SaveFormModal: React.FC<SaveFormModalProps> = ({ form, schema, formUuid, c
         </Form>
       </ModalBody>
       <ModalFooter>
-        <Button kind={'secondary'} onClick={close}>
+        <Button kind={'secondary'} onClick={closeModal}>
           {t('close', 'Close')}
         </Button>
         <Button

--- a/src/components/interactive-builder/modals/save-form/save-form.modal.tsx
+++ b/src/components/interactive-builder/modals/save-form/save-form.modal.tsx
@@ -1,9 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
 import {
   Button,
-  ComposedModal,
   Form,
   FormGroup,
   InlineLoading,
@@ -43,22 +41,21 @@ interface FormGroupData {
 interface SaveFormModalProps {
   form: FormGroupData;
   schema: Schema;
+  formUuid?: string;
+  close: () => void;
+  onSavingChange?: (isSaving: boolean) => void;
 }
 
-const SaveFormModal: React.FC<SaveFormModalProps> = ({ form, schema }) => {
+const SaveFormModal: React.FC<SaveFormModalProps> = ({ form, schema, formUuid, close, onSavingChange }) => {
   const { t } = useTranslation();
   const { encounterTypes } = useEncounterTypes();
-  const { formUuid } = useParams<{ formUuid: string }>();
   const { mutate } = useForm(formUuid);
-  const isSavingNewForm = !formUuid;
   const [description, setDescription] = useState('');
   const [encounterType, setEncounterType] = useState('');
   const [isInvalidVersion, setIsInvalidVersion] = useState(false);
   const [isSavingForm, setIsSavingForm] = useState(false);
   const [name, setName] = useState('');
-  const [openConfirmSaveModal, setOpenConfirmSaveModal] = useState(false);
-  const [openSaveFormModal, setOpenSaveFormModal] = useState(false);
-  const [saveState, setSaveState] = useState('');
+  const [saveState, setSaveState] = useState<'update' | 'newVersion' | null>(formUuid ? null : 'newVersion');
   const [version, setVersion] = useState('');
 
   const clearDraftFormSchema = useCallback(() => localStorage.removeItem('formJSON'), []);
@@ -78,285 +75,248 @@ const SaveFormModal: React.FC<SaveFormModalProps> = ({ form, schema }) => {
     setIsInvalidVersion(!/^[0-9]/.test(version));
   };
 
-  const openModal = useCallback((option: string) => {
-    if (option === 'newVersion') {
-      setSaveState('newVersion');
-      setOpenConfirmSaveModal(false);
-      setOpenSaveFormModal(true);
-    } else if (option === 'new') {
-      setSaveState('newVersion');
-      setOpenSaveFormModal(true);
-    } else if (option === 'update') {
-      setSaveState('update');
-      setOpenConfirmSaveModal(false);
-      setOpenSaveFormModal(true);
-    }
-  }, []);
-
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setIsSavingForm(true);
-
-    const target = event.target as EventTarget & {
-      name: { value: string };
-      version: { value: string };
-      encounterType: { value: string };
-      description: { value: string };
-    };
-
-    if (saveState === 'new' || saveState === 'newVersion') {
-      const name = target.name.value,
-        version = target.version.value,
-        encounterType = target.encounterType.value,
-        description = target.description.value;
-
-      try {
-        const newForm = await saveNewForm(name, version, false, description, encounterType);
-
-        const updatedSchema = {
-          ...schema,
-          name: name,
-          version: version,
-          description: description,
-          encounterType: encounterType,
-          uuid: newForm.uuid,
-        };
-
-        let newValueReference: string | undefined;
+    onSavingChange?.(true);
+    try {
+      if (saveState === 'newVersion') {
         try {
-          newValueReference = (await uploadSchema(updatedSchema)).toString();
-          await getResourceUuid(newForm.uuid, newValueReference);
+          const newForm = await saveNewForm(name, version, false, description, encounterType);
+
+          const updatedSchema = {
+            ...schema,
+            name: name,
+            version: version,
+            description: description,
+            encounterType: encounterType,
+            uuid: newForm.uuid,
+          };
+
+          let newValueReference: string | undefined;
+          try {
+            newValueReference = (await uploadSchema(updatedSchema)).toString();
+            await getResourceUuid(newForm.uuid, newValueReference);
+          } catch (error) {
+            // Clean up the orphaned clobdata and form since schema upload or linking failed
+            if (newValueReference) {
+              await deleteClobdata(newValueReference).catch(() => {});
+            }
+            await deleteForm(newForm.uuid).catch(() => {});
+            throw error;
+          }
+
+          showSnackbar({
+            title: t('formCreated', 'New form created'),
+            kind: 'success',
+            isLowContrast: true,
+            subtitle:
+              name +
+              ' ' +
+              t('saveSuccessMessage', 'was created successfully. It is now visible on the Forms dashboard.'),
+          });
+          clearDraftFormSchema();
+          close();
+          await mutate();
+
+          navigate({
+            to: `${window.spaBase}/form-builder/edit/${newForm.uuid}`,
+          });
         } catch (error) {
-          // Clean up the orphaned clobdata and form since schema upload or linking failed
-          if (newValueReference) {
+          if (error instanceof Error) {
+            showSnackbar({
+              title: t('errorCreatingForm', 'Error creating form'),
+              kind: 'error',
+              subtitle: error?.message,
+            });
+          }
+        }
+      } else {
+        try {
+          const updatedSchema = {
+            ...schema,
+            name: name,
+            version: version,
+            description: description,
+            encounterType: encounterType,
+          };
+
+          await updateForm(form.uuid, name, version, description, encounterType);
+
+          const oldResource = form?.resources?.length
+            ? form.resources.find(({ name }) => name === 'JSON schema')
+            : undefined;
+
+          // Upload the new clobdata first (doesn't affect the live form yet)
+          const newValueReference = (await uploadSchema(updatedSchema)).toString();
+
+          // Swap: remove old resource link, then link the new clobdata.
+          // If the swap fails, clean up the newly uploaded clobdata.
+          try {
+            if (oldResource) {
+              await deleteResource(form.uuid, oldResource.uuid);
+            }
+            await getResourceUuid(form.uuid, newValueReference);
+          } catch (error) {
             await deleteClobdata(newValueReference).catch(() => {});
+            throw error;
           }
-          await deleteForm(newForm.uuid).catch(() => {});
-          throw error;
-        }
 
-        showSnackbar({
-          title: t('formCreated', 'New form created'),
-          kind: 'success',
-          isLowContrast: true,
-          subtitle:
-            name + ' ' + t('saveSuccessMessage', 'was created successfully. It is now visible on the Forms dashboard.'),
-        });
-        clearDraftFormSchema();
-        setOpenSaveFormModal(false);
-        await mutate();
-
-        navigate({
-          to: `${window.spaBase}/form-builder/edit/${newForm.uuid}`,
-        });
-
-        setIsSavingForm(false);
-      } catch (error) {
-        if (error instanceof Error) {
-          showSnackbar({
-            title: t('errorCreatingForm', 'Error creating form'),
-            kind: 'error',
-            subtitle: error?.message,
-          });
-        }
-        setIsSavingForm(false);
-      }
-    } else {
-      try {
-        const updatedSchema = {
-          ...schema,
-          name: name,
-          version: version,
-          description: description,
-          encounterType: encounterType,
-        };
-
-        await updateForm(form.uuid, name, version, description, encounterType);
-
-        const oldResource = form?.resources?.length
-          ? form.resources.find(({ name }) => name === 'JSON schema')
-          : undefined;
-
-        // Upload the new clobdata first (doesn't affect the live form yet)
-        const newValueReference = (await uploadSchema(updatedSchema)).toString();
-
-        // Swap: remove old resource link, then link the new clobdata.
-        // If the swap fails, clean up the newly uploaded clobdata.
-        try {
+          // Clean up old clobdata. If this fails, the form still works
+          // (just an orphaned clobdata row in the database).
           if (oldResource) {
-            await deleteResource(form.uuid, oldResource.uuid);
+            await deleteClobdata(oldResource.valueReference).catch(() => {});
           }
-          await getResourceUuid(form.uuid, newValueReference);
-        } catch (error) {
-          await deleteClobdata(newValueReference).catch(() => {});
-          throw error;
-        }
 
-        // Clean up old clobdata. If this fails, the form still works
-        // (just an orphaned clobdata row in the database).
-        if (oldResource) {
-          await deleteClobdata(oldResource.valueReference).catch(() => {});
-        }
-
-        showSnackbar({
-          title: t('success', 'Success!'),
-          kind: 'success',
-          isLowContrast: true,
-          subtitle: form?.name + ' ' + t('saveSuccess', 'was updated successfully'),
-        });
-        setOpenSaveFormModal(false);
-        await mutate();
-        setIsSavingForm(false);
-      } catch (error) {
-        if (error instanceof Error) {
           showSnackbar({
-            title: t('errorUpdatingForm', 'Error updating form'),
-            kind: 'error',
-            subtitle: error?.message,
+            title: t('success', 'Success!'),
+            kind: 'success',
+            isLowContrast: true,
+            subtitle: form?.name + ' ' + t('saveSuccess', 'was updated successfully'),
           });
+          close();
+          await mutate();
+        } catch (error) {
+          if (error instanceof Error) {
+            showSnackbar({
+              title: t('errorUpdatingForm', 'Error updating form'),
+              kind: 'error',
+              subtitle: error?.message,
+            });
+          }
         }
-
-        setIsSavingForm(false);
       }
+    } finally {
+      setIsSavingForm(false);
+      onSavingChange?.(false);
     }
   };
 
+  if (saveState === null) {
+    return (
+      <>
+        <ModalHeader closeModal={close} title={t('saveConfirmation', 'Save or Update form')} />
+        <ModalBody>
+          <p>
+            {t(
+              'saveAsModal',
+              "A version of the form you're working on already exists on the server. Do you want to update the form or to save it as a new version?",
+            )}
+          </p>
+        </ModalBody>
+        <ModalFooter>
+          <Button kind={'tertiary'} onClick={() => setSaveState('update')}>
+            {t('updateExistingForm', 'Update existing version')}
+          </Button>
+          <Button kind={'primary'} onClick={() => setSaveState('newVersion')}>
+            {t('saveAsNewForm', 'Save as a new form')}
+          </Button>
+          <Button kind={'secondary'} onClick={close}>
+            {t('close', 'Close')}
+          </Button>
+        </ModalFooter>
+      </>
+    );
+  }
+
   return (
     <>
-      {!isSavingNewForm ? (
-        <ComposedModal
-          open={openConfirmSaveModal}
-          onClose={() => setOpenConfirmSaveModal(false)}
-          preventCloseOnClickOutside
-        >
-          <ModalHeader title={t('saveConfirmation', 'Save or Update form')} />
-          <ModalBody>
-            <p>
-              {t(
-                'saveAsModal',
-                "A version of the form you're working on already exists on the server. Do you want to update the form or to save it as a new version?",
-              )}
-            </p>
-          </ModalBody>
-          <ModalFooter>
-            <Button kind={'tertiary'} onClick={() => openModal('update')}>
-              {t('updateExistingForm', 'Update existing version')}
-            </Button>
-            <Button kind={'primary'} onClick={() => openModal('newVersion')}>
-              {t('saveAsNewForm', 'Save as a new form')}
-            </Button>
-            <Button kind={'secondary'} onClick={() => setOpenConfirmSaveModal(false)}>
-              {t('close', 'Close')}
-            </Button>
-          </ModalFooter>
-        </ComposedModal>
-      ) : null}
-
-      <ComposedModal open={openSaveFormModal} onClose={() => setOpenSaveFormModal(false)} preventCloseOnClickOutside>
-        <ModalHeader title={t('saveFormToServer', 'Save form to server')} />
-        <Form onSubmit={handleSubmit} className={styles.saveFormBody}>
-          <ModalBody>
-            <p>
-              {t(
-                'saveExplainerText',
-                'Clicking the Save button saves your form schema to the database. To see your form in your frontend, you first need to publish it. Click the Publish button to publish your form.',
-              )}
-            </p>
-            <FormGroup legendText={''}>
-              <Stack gap={5}>
+      <ModalHeader closeModal={close} title={t('saveFormToServer', 'Save form to server')} />
+      <ModalBody>
+        <Form id="save-form" onSubmit={handleSubmit} className={styles.saveFormBody}>
+          <p>
+            {t(
+              'saveExplainerText',
+              'Clicking the Save button saves your form schema to the database. To see your form in your frontend, you first need to publish it. Click the Publish button to publish your form.',
+            )}
+          </p>
+          <FormGroup legendText={''}>
+            <Stack gap={5}>
+              <TextInput
+                id="name"
+                labelText={t('formName', 'Form Name')}
+                onChange={(event: React.ChangeEvent<HTMLInputElement>) => setName(event.target.value)}
+                placeholder={t('formNamePlaceholder', 'e.g. OHRI Express Care Patient Encounter Form')}
+                required
+                value={name}
+              />
+              {saveState === 'update' ? (
                 <TextInput
-                  id="name"
-                  labelText={t('formName', 'Form Name')}
-                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => setName(event.target.value)}
-                  placeholder={t('formNamePlaceholder', 'e.g. OHRI Express Care Patient Encounter Form')}
-                  required
-                  value={name}
+                  id="uuid"
+                  labelText={t('autogeneratedUuid', 'UUID (auto-generated)')}
+                  disabled
+                  value={form?.uuid}
                 />
-                {saveState === 'update' ? (
-                  <TextInput
-                    id="uuid"
-                    labelText={t('autogeneratedUuid', 'UUID (auto-generated)')}
-                    disabled
-                    value={form?.uuid}
+              ) : null}
+              <TextInput
+                id="version"
+                labelText={t('version', 'Version')}
+                placeholder={t('versionPlaceholder', 'e.g. 1.0')}
+                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                  checkVersionValidity(event.target.value);
+
+                  if (!isInvalidVersion) {
+                    setVersion(event.target.value);
+                  }
+                }}
+                invalid={isInvalidVersion}
+                invalidText={t('invalidVersionWarning', 'Version can only start with with a number')}
+                required
+                value={version}
+              />
+              <Select
+                id="encounterType"
+                labelText={t('encounterType', 'Encounter Type')}
+                onChange={(event: React.ChangeEvent<HTMLSelectElement>) => setEncounterType(event.target.value)}
+                required
+                value={encounterType}
+              >
+                {!encounterType ? (
+                  <SelectItem
+                    text={t('chooseEncounterType', 'Choose an encounter type to link your form to')}
+                    value=""
                   />
                 ) : null}
-                <TextInput
-                  id="version"
-                  labelText={t('version', 'Version')}
-                  placeholder={t('versionPlaceholder', 'e.g. 1.0')}
-                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                    checkVersionValidity(event.target.value);
-
-                    if (!isInvalidVersion) {
-                      setVersion(event.target.value);
-                    }
-                  }}
-                  invalid={isInvalidVersion}
-                  invalidText={t('invalidVersionWarning', 'Version can only start with with a number')}
-                  required
-                  value={version}
-                />
-                <Select
-                  id="encounterType"
-                  labelText={t('encounterType', 'Encounter Type')}
-                  onChange={(event: React.ChangeEvent<HTMLSelectElement>) => setEncounterType(event.target.value)}
-                  required
-                  value={encounterType}
-                >
-                  {!encounterType ? (
-                    <SelectItem
-                      text={t('chooseEncounterType', 'Choose an encounter type to link your form to')}
-                      value=""
-                    />
-                  ) : null}
-                  {encounterTypes?.length > 0 &&
-                    encounterTypes.map((encounterType) => (
-                      <SelectItem key={encounterType.uuid} value={encounterType.uuid} text={encounterType.name}>
-                        {encounterType.name}
-                      </SelectItem>
-                    ))}
-                </Select>
-                <TextArea
-                  labelText={t('description', 'Description')}
-                  onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => setDescription(event.target.value)}
-                  id="description"
-                  placeholder={t(
-                    'descriptionPlaceholderText',
-                    'e.g. A form used to collect encounter data for clients in the Express Care program.',
-                  )}
-                  required
-                  value={description}
-                />
-              </Stack>
-            </FormGroup>
-          </ModalBody>
-          <ModalFooter>
-            <Button kind={'secondary'} onClick={() => setOpenSaveFormModal(false)}>
-              {t('close', 'Close')}
-            </Button>
-            <Button
-              disabled={isSavingForm || isInvalidVersion}
-              className={styles.spinner}
-              type={'submit'}
-              kind={'primary'}
-            >
-              {isSavingForm ? (
-                <InlineLoading description={t('saving', 'Saving') + '...'} />
-              ) : (
-                <span>{t('save', 'Save')}</span>
-              )}
-            </Button>
-          </ModalFooter>
+                {encounterTypes?.length > 0 &&
+                  encounterTypes.map((encounterType) => (
+                    <SelectItem key={encounterType.uuid} value={encounterType.uuid} text={encounterType.name}>
+                      {encounterType.name}
+                    </SelectItem>
+                  ))}
+              </Select>
+              <TextArea
+                labelText={t('description', 'Description')}
+                onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => setDescription(event.target.value)}
+                id="description"
+                placeholder={t(
+                  'descriptionPlaceholderText',
+                  'e.g. A form used to collect encounter data for clients in the Express Care program.',
+                )}
+                required
+                value={description}
+              />
+            </Stack>
+          </FormGroup>
         </Form>
-      </ComposedModal>
-
-      <Button
-        disabled={!schema}
-        kind="primary"
-        onClick={() => (isSavingNewForm ? openModal('new') : setOpenConfirmSaveModal(true))}
-      >
-        {t('saveForm', 'Save form')}
-      </Button>
+      </ModalBody>
+      <ModalFooter>
+        <Button kind={'secondary'} onClick={close}>
+          {t('close', 'Close')}
+        </Button>
+        <Button
+          disabled={isSavingForm || isInvalidVersion}
+          className={styles.spinner}
+          type={'submit'}
+          form="save-form"
+          kind={'primary'}
+        >
+          {isSavingForm ? (
+            <InlineLoading description={t('saving', 'Saving') + '...'} />
+          ) : (
+            <span>{t('save', 'Save')}</span>
+          )}
+        </Button>
+      </ModalFooter>
     </>
   );
 };

--- a/src/components/interactive-builder/modals/save-form/save-form.scss
+++ b/src/components/interactive-builder/modals/save-form/save-form.scss
@@ -9,8 +9,3 @@
     font-size: unset;
   }
 }
-
-.saveFormBody {
-  max-height: 75vh;
-  overflow-y: auto;
-}

--- a/src/components/interactive-builder/modals/save-form/save-form.test.tsx
+++ b/src/components/interactive-builder/modals/save-form/save-form.test.tsx
@@ -74,10 +74,10 @@ beforeEach(() => {
 describe('save form modal', () => {
   it('creates a new form without a router provider', async () => {
     const user = userEvent.setup();
-    const close = vi.fn();
-    render(<SaveFormModal schema={schema} form={undefined} close={close} />);
+    const closeModal = vi.fn();
+    render(<SaveFormModal schema={schema} form={undefined} closeModal={closeModal} />);
     await user.click(screen.getByRole('button', { name: 'Save' }));
-    await waitFor(() => expect(close).toHaveBeenCalledOnce());
+    await waitFor(() => expect(closeModal).toHaveBeenCalledOnce());
     expect(saveNewForm).toHaveBeenCalledWith('Nutrition', '1.0', false, 'Nutrition form', 'encounter-type');
     expect(getResourceUuid).toHaveBeenCalledWith('new-form', 'new-clob');
     expect(updateForm).not.toHaveBeenCalled();
@@ -88,13 +88,13 @@ describe('save form modal', () => {
 
   it('updates the selected existing form after the confirmation step', async () => {
     const user = userEvent.setup();
-    const close = vi.fn();
-    render(<SaveFormModal schema={schema} form={form} formUuid="existing-form" close={close} />);
+    const closeModal = vi.fn();
+    render(<SaveFormModal schema={schema} form={form} formUuid="existing-form" closeModal={closeModal} />);
     expect(useForm).toHaveBeenCalledWith('existing-form');
     expect(screen.queryByRole('textbox', { name: 'Form Name' })).not.toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'Update existing version' }));
     await user.click(screen.getByRole('button', { name: 'Save' }));
-    await waitFor(() => expect(close).toHaveBeenCalledOnce());
+    await waitFor(() => expect(closeModal).toHaveBeenCalledOnce());
     expect(updateForm).toHaveBeenCalledWith('existing-form', 'Nutrition', '1.0', 'Nutrition form', 'encounter-type');
     expect(getResourceUuid).toHaveBeenCalledWith('existing-form', 'new-clob');
     expect(deleteResource).toHaveBeenCalledWith('existing-form', 'old-link');
@@ -104,7 +104,7 @@ describe('save form modal', () => {
 
   it('creates a new version instead of updating the old form', async () => {
     const user = userEvent.setup();
-    render(<SaveFormModal schema={schema} form={form} formUuid="existing-form" close={vi.fn()} />);
+    render(<SaveFormModal schema={schema} form={form} formUuid="existing-form" closeModal={vi.fn()} />);
     await user.click(screen.getByRole('button', { name: 'Save as a new form' }));
     await user.click(screen.getByRole('button', { name: 'Save' }));
     await waitFor(() => expect(saveNewForm).toHaveBeenCalledOnce());
@@ -114,14 +114,14 @@ describe('save form modal', () => {
 
   it('keeps failed saves open and cancellation does not save', async () => {
     const user = userEvent.setup();
-    const close = vi.fn();
+    const closeModal = vi.fn();
     vi.mocked(saveNewForm).mockRejectedValueOnce(new Error('Cannot save'));
-    render(<SaveFormModal schema={schema} form={undefined} close={close} />);
+    render(<SaveFormModal schema={schema} form={undefined} closeModal={closeModal} />);
     await user.click(screen.getByRole('button', { name: 'Save' }));
     await waitFor(() => expect(showSnackbar).toHaveBeenCalledWith(expect.objectContaining({ kind: 'error' })));
-    expect(close).not.toHaveBeenCalled();
+    expect(closeModal).not.toHaveBeenCalled();
     await user.click(screen.getAllByRole('button', { name: 'Close' }).at(-1));
-    expect(close).toHaveBeenCalledOnce();
+    expect(closeModal).toHaveBeenCalledOnce();
     expect(saveNewForm).toHaveBeenCalledOnce();
   });
   it.each(['success', 'failure'])(
@@ -154,16 +154,16 @@ describe('save form modal', () => {
         );
       };
       vi.mocked(showModal).mockImplementation((name, props) => {
-        const close = () => view.unmount();
+        const closeModal = () => view.unmount();
         const view = render(
           <SaveFormModal
             schema={schema}
             form={undefined}
             onSavingChange={props.onSavingChange as React.ComponentProps<typeof SaveFormModal>['onSavingChange']}
-            close={close}
+            closeModal={props.closeModal as React.ComponentProps<typeof SaveFormModal>['closeModal']}
           />,
         );
-        return close;
+        return closeModal;
       });
       render(<Launcher />);
       const launcher = screen.getByRole('button', { name: 'Save form' });
@@ -175,7 +175,7 @@ describe('save form modal', () => {
       expect(showModal).toHaveBeenCalledOnce();
       expect(showModal).toHaveBeenCalledWith(
         'save-form-modal',
-        expect.objectContaining({ schema, onSavingChange: expect.any(Function) }),
+        expect.objectContaining({ schema, closeModal: expect.any(Function), onSavingChange: expect.any(Function) }),
       );
       expect(saveNewForm).toHaveBeenCalledOnce();
       await act(async () => {

--- a/src/components/interactive-builder/modals/save-form/save-form.test.tsx
+++ b/src/components/interactive-builder/modals/save-form/save-form.test.tsx
@@ -173,6 +173,10 @@ describe('save form modal', () => {
       expect(launcher).toBeDisabled();
       await user.click(launcher);
       expect(showModal).toHaveBeenCalledOnce();
+      expect(showModal).toHaveBeenCalledWith(
+        'save-form-modal',
+        expect.objectContaining({ schema, onSavingChange: expect.any(Function) }),
+      );
       expect(saveNewForm).toHaveBeenCalledOnce();
       await act(async () => {
         if (outcome === 'success') {

--- a/src/components/interactive-builder/modals/save-form/save-form.test.tsx
+++ b/src/components/interactive-builder/modals/save-form/save-form.test.tsx
@@ -1,0 +1,188 @@
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { navigate, showSnackbar, showModal, useConfig } from '@openmrs/esm-framework';
+import { useForm } from '@hooks/useForm';
+import { useEncounterTypes } from '@hooks/useEncounterTypes';
+import {
+  saveNewForm,
+  updateForm,
+  uploadSchema,
+  getResourceUuid,
+  deleteResource,
+  deleteClobdata,
+} from '@resources/forms.resource';
+import SaveFormModal from './save-form.modal';
+import ActionButtons from '../../../action-buttons/action-buttons.component';
+import { MemoryRouter } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+
+vi.mock('@hooks/useForm');
+vi.mock('@hooks/useEncounterTypes');
+vi.mock('@resources/forms.resource');
+
+const schema = {
+  name: 'Nutrition',
+  version: '1.0',
+  description: 'Nutrition form',
+  encounterType: 'encounter-type',
+  pages: [],
+} as React.ComponentProps<typeof SaveFormModal>['schema'];
+const form = {
+  uuid: 'existing-form',
+  name: 'Nutrition',
+  version: '1.0',
+  description: 'Nutrition form',
+  resources: [{ uuid: 'old-link', name: 'JSON schema', valueReference: 'old-clob' }],
+} as React.ComponentProps<typeof SaveFormModal>['form'];
+const mutate = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+  vi.mocked(useForm).mockReturnValue({
+    mutate,
+    form: undefined,
+    formError: undefined,
+    isLoadingForm: false,
+    isValidatingForm: false,
+  });
+  vi.mocked(useEncounterTypes).mockReturnValue({
+    encounterTypes: [{ uuid: 'encounter-type', name: 'Nutrition encounter' }],
+  } as ReturnType<typeof useEncounterTypes>);
+  vi.mocked(uploadSchema).mockResolvedValue('new-clob');
+  vi.mocked(saveNewForm).mockResolvedValue({
+    ...form,
+    uuid: 'new-form',
+    encounterType: { uuid: 'encounter-type', name: 'Nutrition encounter', display: 'Nutrition encounter' },
+    resources: [],
+    auditInfo: undefined,
+  });
+  vi.mocked(updateForm).mockResolvedValue(undefined);
+  vi.mocked(getResourceUuid).mockResolvedValue(undefined);
+  vi.mocked(deleteResource).mockResolvedValue(undefined);
+  vi.mocked(deleteClobdata).mockResolvedValue(undefined);
+});
+
+describe('save form modal', () => {
+  it('creates a new form without a router provider', async () => {
+    const user = userEvent.setup();
+    const close = vi.fn();
+    render(<SaveFormModal schema={schema} form={undefined} close={close} />);
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(close).toHaveBeenCalledOnce());
+    expect(saveNewForm).toHaveBeenCalledWith('Nutrition', '1.0', false, 'Nutrition form', 'encounter-type');
+    expect(getResourceUuid).toHaveBeenCalledWith('new-form', 'new-clob');
+    expect(updateForm).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(navigate).toHaveBeenCalledWith(expect.objectContaining({ to: expect.stringContaining('/edit/new-form') })),
+    );
+  });
+
+  it('updates the selected existing form after the confirmation step', async () => {
+    const user = userEvent.setup();
+    const close = vi.fn();
+    render(<SaveFormModal schema={schema} form={form} formUuid="existing-form" close={close} />);
+    expect(useForm).toHaveBeenCalledWith('existing-form');
+    expect(screen.queryByRole('textbox', { name: 'Form Name' })).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Update existing version' }));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(close).toHaveBeenCalledOnce());
+    expect(updateForm).toHaveBeenCalledWith('existing-form', 'Nutrition', '1.0', 'Nutrition form', 'encounter-type');
+    expect(getResourceUuid).toHaveBeenCalledWith('existing-form', 'new-clob');
+    expect(deleteResource).toHaveBeenCalledWith('existing-form', 'old-link');
+    expect(deleteClobdata).toHaveBeenCalledWith('old-clob');
+    expect(saveNewForm).not.toHaveBeenCalled();
+  });
+
+  it('creates a new version instead of updating the old form', async () => {
+    const user = userEvent.setup();
+    render(<SaveFormModal schema={schema} form={form} formUuid="existing-form" close={vi.fn()} />);
+    await user.click(screen.getByRole('button', { name: 'Save as a new form' }));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(saveNewForm).toHaveBeenCalledOnce());
+    expect(updateForm).not.toHaveBeenCalled();
+    expect(deleteResource).not.toHaveBeenCalled();
+  });
+
+  it('keeps failed saves open and cancellation does not save', async () => {
+    const user = userEvent.setup();
+    const close = vi.fn();
+    vi.mocked(saveNewForm).mockRejectedValueOnce(new Error('Cannot save'));
+    render(<SaveFormModal schema={schema} form={undefined} close={close} />);
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(showSnackbar).toHaveBeenCalledWith(expect.objectContaining({ kind: 'error' })));
+    expect(close).not.toHaveBeenCalled();
+    await user.click(screen.getAllByRole('button', { name: 'Close' }).at(-1));
+    expect(close).toHaveBeenCalledOnce();
+    expect(saveNewForm).toHaveBeenCalledOnce();
+  });
+  it.each(['success', 'failure'])(
+    'blocks reopening after dismissal until a pending save settles: %s',
+    async (outcome) => {
+      let resolve: (value: Awaited<ReturnType<typeof saveNewForm>>) => void;
+      let reject: (error: Error) => void;
+      const pending = new Promise<Awaited<ReturnType<typeof saveNewForm>>>((done, fail) => {
+        resolve = done;
+        reject = fail;
+      });
+      vi.mocked(saveNewForm).mockReturnValueOnce(pending);
+      vi.mocked(useConfig).mockReturnValue({});
+      const user = userEvent.setup();
+      const Launcher = () => {
+        const { t } = useTranslation();
+        return (
+          <MemoryRouter>
+            <ActionButtons
+              schema={schema}
+              t={t}
+              isValidating={false}
+              schemaErrors={[]}
+              onFormValidation={vi.fn()}
+              setPublishedWithErrors={vi.fn()}
+              setValidationComplete={vi.fn()}
+              setValidationResponse={vi.fn()}
+            />
+          </MemoryRouter>
+        );
+      };
+      vi.mocked(showModal).mockImplementation((name, props) => {
+        const close = () => view.unmount();
+        const view = render(
+          <SaveFormModal
+            schema={schema}
+            form={undefined}
+            onSavingChange={props.onSavingChange as React.ComponentProps<typeof SaveFormModal>['onSavingChange']}
+            close={close}
+          />,
+        );
+        return close;
+      });
+      render(<Launcher />);
+      const launcher = screen.getByRole('button', { name: 'Save form' });
+      await user.click(launcher);
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+      await user.click(screen.getAllByRole('button', { name: 'Close' }).at(-1));
+      expect(launcher).toBeDisabled();
+      await user.click(launcher);
+      expect(showModal).toHaveBeenCalledOnce();
+      expect(saveNewForm).toHaveBeenCalledOnce();
+      await act(async () => {
+        if (outcome === 'success') {
+          resolve({ ...form, uuid: 'new-form', encounterType: undefined, resources: [], auditInfo: undefined });
+        } else {
+          reject(new Error('Cannot save'));
+        }
+        await pending.catch(() => {});
+      });
+      await waitFor(() => expect(launcher).toBeEnabled());
+    },
+  );
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,3 +80,8 @@ export const editTranslationModal = getAsyncLifecycle(
 export function startupApp() {
   defineConfigSchema(moduleName, configSchema);
 }
+
+export const saveFormModal = getAsyncLifecycle(
+  () => import('./components/interactive-builder/modals/save-form/save-form.modal'),
+  options,
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,11 +77,11 @@ export const editTranslationModal = getAsyncLifecycle(
   options,
 );
 
-export function startupApp() {
-  defineConfigSchema(moduleName, configSchema);
-}
-
 export const saveFormModal = getAsyncLifecycle(
   () => import('./components/interactive-builder/modals/save-form/save-form.modal'),
   options,
 );
+
+export function startupApp() {
+  defineConfigSchema(moduleName, configSchema);
+}

--- a/src/routes.json
+++ b/src/routes.json
@@ -74,6 +74,10 @@
     {
       "name": "edit-translation-modal",
       "component": "editTranslationModal"
+    },
+    {
+      "name": "save-form-modal",
+      "component": "saveFormModal"
     }
   ]
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.

## Summary

Move form saving into a registered framework modal, with the form identifier and schema passed from the editor. Preserve both update and new-version flows, and keep pending-save state in the launcher so dismissing a save cannot start a second request.

The separate footer submit button targets the form explicitly. The E2E fixes select the exact reference-form fixture and wait for the schema editor to update after page deletion.

## Screenshots

## Related Issue

## Other
